### PR TITLE
fix(mobile): sync on startup

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -287,6 +287,10 @@ function RootLayoutContent() {
           if (!isActive.current) return;
           updateAndroidWidgetFromStore().catch(logAppError);
         }, 800);
+        // Initial sync after cold start
+        if (!cancelled && isActive.current) {
+          requestSync(0);
+        }
       } catch (e) {
         void logError(e, { scope: 'app', extra: { message: 'Failed to load data' } });
         if (cancelled) return;
@@ -329,7 +333,7 @@ function RootLayoutContent() {
         widgetRefreshTimer.current = null;
       }
     };
-  }, [storageWarningShown, storageInitError]);
+  }, [storageWarningShown, storageInitError, requestSync]);
 
   useEffect(() => {
     let previousEnabled = useTaskStore.getState().settings.notificationsEnabled;


### PR DESCRIPTION
The mobile app loads local data on startup but never pulls remote changes until the user backgrounds/foregrounds the app or makes a local edit.
This adds an initial `requestSync(0)` call after `fetchData()` succeeds, mirroring the desktop app's post-startup sync.