### PR TITLE
Fix desktop WebDAV first-sync failure on 404 Not Found

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2229,6 +2229,10 @@ fn webdav_get_json(app: tauri::AppHandle) -> Result<Value, String> {
         .send()
         .map_err(|e| format!("WebDAV request failed: {e}"))?;
 
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(Value::Null);
+    }
+  
     if !response.status().is_success() {
         return Err(format!("WebDAV error: {}", response.status()));
     }


### PR DESCRIPTION
## Summary
This PR fixes desktop WebDAV sync behavior during first-time setup.

When `data.json` is not present yet on the remote WebDAV folder, servers (e.g. Nextcloud) can return `404 Not Found` on read. Desktop previously treated this as a fatal sync error.

The WebDAV read command now treats `404` as an empty remote state (`null`), matching expected first-sync semantics.

## Why
Users can have a correct WebDAV URL/username/password and still get a 404 on initial sync simply because the remote file does not exist yet.

## Behavior after this change
- `404` on WebDAV read no longer aborts sync initialization.
- Initial sync can continue and create/write `data.json`.
- Real WebDAV errors (non-success statuses other than 404) are still surfaced.

## Scope
- Desktop (Tauri) WebDAV read path only.
- No change to authentication handling or write behavior.
