### PR TITLE
fix: loose equality to null on timestamp checks in validateAppData

### DIFF
--- a/apps/cloud/src/server.test.ts
+++ b/apps/cloud/src/server.test.ts
@@ -76,6 +76,44 @@ describe('cloud server utils', () => {
         expect(invalidTimestamp.ok).toBe(false);
     });
 
+    test('accepts null optional timestamps in tasks, projects, sections, and areas', () => {
+     const iso = '2024-01-01T00:00:00.000Z';
+     const result = __cloudTestUtils.validateAppData({
+         tasks: [{
+             id: 't1',
+             title: 'Task',
+             status: 'inbox',
+             createdAt: iso,
+             updatedAt: iso,
+             deletedAt: null,
+         }],
+         projects: [{
+             id: 'p1',
+             title: 'Project',
+             status: 'active',
+             createdAt: iso,
+             updatedAt: iso,
+             deletedAt: null,
+         }],
+         sections: [{
+             id: 's1',
+             projectId: 'p1',
+             title: 'Section',
+             createdAt: iso,
+             updatedAt: iso,
+             deletedAt: null,
+         }],
+         areas: [{
+             id: 'a1',
+             name: 'Area',
+             createdAt: null,
+             updatedAt: null,
+             deletedAt: null,
+         }],
+     });
+     expect(result.ok).toBe(true);
+    });
+
     test('accepts only core task statuses', () => {
         expect(__cloudTestUtils.asStatus('reference')).toBe('reference');
         expect(__cloudTestUtils.asStatus('todo')).toBeNull();

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -237,7 +237,7 @@ function validateAppData(value: unknown): { ok: true; data: Record<string, unkno
         if (!isValidIsoTimestamp(task.createdAt) || !isValidIsoTimestamp(task.updatedAt)) {
             return { ok: false, error: 'Invalid data: task createdAt/updatedAt must be valid ISO timestamps' };
         }
-        if (task.deletedAt !== undefined && !isValidIsoTimestamp(task.deletedAt)) {
+        if (task.deletedAt != null && !isValidIsoTimestamp(task.deletedAt)) {
             return { ok: false, error: 'Invalid data: task deletedAt must be a valid ISO timestamp when present' };
         }
     }
@@ -255,7 +255,7 @@ function validateAppData(value: unknown): { ok: true; data: Record<string, unkno
         if (!isValidIsoTimestamp(project.createdAt) || !isValidIsoTimestamp(project.updatedAt)) {
             return { ok: false, error: 'Invalid data: project createdAt/updatedAt must be valid ISO timestamps' };
         }
-        if (project.deletedAt !== undefined && !isValidIsoTimestamp(project.deletedAt)) {
+        if (project.deletedAt != null && !isValidIsoTimestamp(project.deletedAt)) {
             return { ok: false, error: 'Invalid data: project deletedAt must be a valid ISO timestamp when present' };
         }
     }
@@ -268,7 +268,7 @@ function validateAppData(value: unknown): { ok: true; data: Record<string, unkno
             if (!isValidIsoTimestamp(section.createdAt) || !isValidIsoTimestamp(section.updatedAt)) {
                 return { ok: false, error: 'Invalid data: section createdAt/updatedAt must be valid ISO timestamps' };
             }
-            if (section.deletedAt !== undefined && !isValidIsoTimestamp(section.deletedAt)) {
+            if (section.deletedAt != null && !isValidIsoTimestamp(section.deletedAt)) {
                 return { ok: false, error: 'Invalid data: section deletedAt must be a valid ISO timestamp when present' };
             }
         }
@@ -279,13 +279,13 @@ function validateAppData(value: unknown): { ok: true; data: Record<string, unkno
             if (!isRecord(area) || typeof area.id !== 'string' || typeof area.name !== 'string') {
                 return { ok: false, error: 'Invalid data: each area must be an object with string id and name' };
             }
-            if (area.createdAt !== undefined && !isValidIsoTimestamp(area.createdAt)) {
+            if (area.createdAt != null && !isValidIsoTimestamp(area.createdAt)) {
                 return { ok: false, error: 'Invalid data: area createdAt must be a valid ISO timestamp when present' };
             }
-            if (area.updatedAt !== undefined && !isValidIsoTimestamp(area.updatedAt)) {
+            if (area.updatedAt != null && !isValidIsoTimestamp(area.updatedAt)) {
                 return { ok: false, error: 'Invalid data: area updatedAt must be a valid ISO timestamp when present' };
             }
-            if (area.deletedAt !== undefined && !isValidIsoTimestamp(area.deletedAt)) {
+            if (area.deletedAt != null && !isValidIsoTimestamp(area.deletedAt)) {
                 return { ok: false, error: 'Invalid data: area deletedAt must be a valid ISO timestamp when present' };
             }
         }


### PR DESCRIPTION
Fixes Issue #160 

# Platform
[x] Cloud server
[x] mobile

# Summary
Change !== undefined to != null (loose equality) on all 6 optional timestamp checks in validateAppData in the file apps/cloud/src/server.ts

# Tests
Regression test added and passed like suggested. Fails with the old check "==! undefined", passes with the modifications.

`bun test apps/cloud/src/server.test.ts
bun test v1.3.9 (cf6cdbbb)

apps/cloud/src/server.test.ts:
✓ cloud server utils > parses bearer token and hashes it
✓ cloud server utils > parses optional auth token allowlist [0.60ms]
✓ cloud server utils > resolves auth tokens from both current and legacy env var names [0.12ms]
✓ cloud server utils > rejects invalid app data payload [0.07ms]
✓ cloud server utils > rejects invalid task status and timestamps in app data [0.14ms]
✓ cloud server utils > accepts null optional timestamps in tasks, projects, sections, and areas [0.03ms]
✓ cloud server utils > accepts only core task statuses [0.04ms]
✓ cloud server utils > normalizes rate limit routes for task item endpoints [0.04ms]
✓ cloud server utils > enforces JSON body size limit [0.05ms]
✓ cloud server utils > normalizes attachment paths with allowlist and segment checks [0.15ms]
✓ cloud server utils > checks whether resolved path stays inside root directory [0.07ms]
{"ts":"2026-02-15T21:14:08.130Z","level":"info","scope":"cloud","message":"dataDir: /var/folders/0p/_8l2r0c12pg71nqp4cz2mkjm0000gn/T/mindwtr-cloud-test-CpC68H"}
{"ts":"2026-02-15T21:14:08.130Z","level":"info","scope":"cloud","message":"token auth allowlist enabled","context":{"allowedTokens":"1"}}
{"ts":"2026-02-15T21:14:08.131Z","level":"info","scope":"cloud","message":"listening on http://127.0.0.1:0"}
✓ cloud server api > supports task CRUD and soft delete flow [5.49ms]
{"ts":"2026-02-15T21:14:08.135Z","level":"info","scope":"cloud","message":"dataDir: /var/folders/0p/_8l2r0c12pg71nqp4cz2mkjm0000gn/T/mindwtr-cloud-test-NGKbVI"}
{"ts":"2026-02-15T21:14:08.135Z","level":"info","scope":"cloud","message":"token auth allowlist enabled","context":{"allowedTokens":"1"}}
{"ts":"2026-02-15T21:14:08.135Z","level":"info","scope":"cloud","message":"listening on http://127.0.0.1:0"}
✓ cloud server api > supports attachment upload/download/delete endpoints [2.14ms]
{"ts":"2026-02-15T21:14:08.137Z","level":"info","scope":"cloud","message":"dataDir: /var/folders/0p/_8l2r0c12pg71nqp4cz2mkjm0000gn/T/mindwtr-cloud-test-TSOVZD"}
{"ts":"2026-02-15T21:14:08.137Z","level":"info","scope":"cloud","message":"token auth allowlist enabled","context":{"allowedTokens":"1"}}
{"ts":"2026-02-15T21:14:08.137Z","level":"info","scope":"cloud","message":"listening on http://127.0.0.1:0"}
{"ts":"2026-02-15T21:14:08.138Z","level":"info","scope":"cloud","message":"dataDir: /var/folders/0p/_8l2r0c12pg71nqp4cz2mkjm0000gn/T/mindwtr-cloud-test-TSOVZD"}
{"ts":"2026-02-15T21:14:08.138Z","level":"info","scope":"cloud","message":"token auth allowlist enabled","context":{"allowedTokens":"1"}}
{"ts":"2026-02-15T21:14:08.138Z","level":"info","scope":"cloud","message":"listening on http://127.0.0.1:0"}
✓ cloud server api > applies attachment endpoint rate limits [2.45ms]
{"ts":"2026-02-15T21:14:08.140Z","level":"info","scope":"cloud","message":"dataDir: /var/folders/0p/_8l2r0c12pg71nqp4cz2mkjm0000gn/T/mindwtr-cloud-test-Qcyp2h"}
{"ts":"2026-02-15T21:14:08.140Z","level":"info","scope":"cloud","message":"token auth allowlist enabled","context":{"allowedTokens":"1"}}
{"ts":"2026-02-15T21:14:08.140Z","level":"info","scope":"cloud","message":"listening on http://127.0.0.1:0"}
✓ cloud server api > serializes concurrent task writes without dropping records [3.84ms]
{"ts":"2026-02-15T21:14:08.143Z","level":"info","scope":"cloud","message":"dataDir: /var/folders/0p/_8l2r0c12pg71nqp4cz2mkjm0000gn/T/mindwtr-cloud-test-kqvxKH"}
{"ts":"2026-02-15T21:14:08.143Z","level":"info","scope":"cloud","message":"token auth allowlist enabled","context":{"allowedTokens":"1"}}
{"ts":"2026-02-15T21:14:08.143Z","level":"info","scope":"cloud","message":"listening on http://127.0.0.1:0"}
✓ cloud server api > merges /v1/data payload with existing server state [2.41ms]

 16 pass
 0 fail
 97 expect() calls
Ran 16 tests across 1 file. [66.00ms]`

