### PR TITLE
fix: sort projects by order field in task picker

### DIFF
--- a/apps/mobile/components/task-edit/TaskEditProjectPicker.tsx
+++ b/apps/mobile/components/task-edit/TaskEditProjectPicker.tsx
@@ -33,7 +33,11 @@ export function TaskEditProjectPicker({
     const activeProjects = useMemo(() => {
         return projects
             .filter((project) => !project.deletedAt)
-            .sort((a, b) => a.title.localeCompare(b.title));
+            .sort((a, b) => {
+                const orderA = Number.isFinite(a.order) ? a.order : 0;
+                const orderB = Number.isFinite(b.order) ? b.order : 0;
+                return orderA - orderB;
+            });
     }, [projects]);
 
     const normalizedProjectQuery = projectQuery.trim().toLowerCase();


### PR DESCRIPTION
Fixes #252

Sort projects by their `order` field instead of alphabetically to match the order shown in the projects view where users can manually reorder projects.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*