### PR TITLE
Harden macOS stability, fix idle flicker, and add native CloudKit sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ scripts/ci/__pycache__/
 
 # Wiki (maintained in separate repo)
 Mindwtr.wiki/
+
+# Local workspace configuration
+pnpm-workspace.yaml

--- a/apps/mobile/components/daily-review-modal.test.tsx
+++ b/apps/mobile/components/daily-review-modal.test.tsx
@@ -3,6 +3,7 @@ import { act, create } from 'react-test-renderer';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DailyReviewScreen } from './daily-review-modal';
+import { SwipeableTaskItem } from './swipeable-task-item';
 
 vi.mock('@mindwtr/core', () => ({
   useTaskStore: () => ({
@@ -134,7 +135,7 @@ describe('DailyReviewScreen', () => {
       nextStepButton.props.onPress();
     });
 
-    const taskRows = tree.root.findAllByType('SwipeableTaskItem');
+    const taskRows = tree.root.findAllByType(SwipeableTaskItem);
     expect(taskRows).toHaveLength(1);
     expect(taskRows[0].props.showFocusToggle).toBe(true);
     expect(taskRows[0].props.hideStatusBadge).toBe(true);


### PR DESCRIPTION
- **macOS desktop stability**: Fix unsafe EventKit FFI (use-after-free), replace `.unwrap()` panics in startup/audio paths with graceful fallbacks, add 5-second safety timeout on window close, log keyring failures instead of swallowing them
- **Idle screen flicker**: Replace `Date.now()` in Layout render path with a 60s timer-driven freshness bucket; add shallow equality selectors and `memo()` to prevent unnecessary re-renders
- **iCloud Drive hardening**: Detect `.icloud` placeholder files from Optimize Storage eviction, add advisory file locking during sync writes, fall back to copy when atomic rename fails on iCloud's virtual filesystem, filter housekeeping events (`.icloud`, `.lock`, `.tmp`) in the local-data-watcher
- **Native CloudKit sync (iOS)**: New Expo native module (`modules/cloudkit-sync/`) bridging CKContainer to the existing Zustand sync engine — custom zone with incremental change token sync, silent push subscriptions, fetch-before-save to avoid server conflicts, proper partial failure handling, and thread-safe record callbacks
- **Misc fixes**: Correct keyboard shortcut labels for macOS (⌘ vs Ctrl), fix `triggerGlobalSearch` sending both metaKey and ctrlKey, reduce sync error throttle from 10min to 2min, stabilize desktop arch test suite
