### PR TITLE
fix(test): use component reference in daily review test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ scripts/ci/__pycache__/
 
 # Wiki (maintained in separate repo)
 Mindwtr.wiki/
+
+# Local workspace configuration
+pnpm-workspace.yaml

--- a/apps/mobile/components/daily-review-modal.test.tsx
+++ b/apps/mobile/components/daily-review-modal.test.tsx
@@ -3,6 +3,7 @@ import { act, create } from 'react-test-renderer';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DailyReviewScreen } from './daily-review-modal';
+import { SwipeableTaskItem } from './swipeable-task-item';
 
 vi.mock('@mindwtr/core', () => ({
   useTaskStore: () => ({
@@ -134,7 +135,7 @@ describe('DailyReviewScreen', () => {
       nextStepButton.props.onPress();
     });
 
-    const taskRows = tree.root.findAll((node) => String(node.type) === 'SwipeableTaskItem');
+    const taskRows = tree.root.findAllByType(SwipeableTaskItem);
     expect(taskRows).toHaveLength(1);
     expect(taskRows[0].props.showFocusToggle).toBe(true);
     expect(taskRows[0].props.hideStatusBadge).toBe(true);


### PR DESCRIPTION
This replaces the stale/conflicting contents of #303 with the current two-file diff only.

Changes:
- use the mocked `SwipeableTaskItem` component reference in `daily-review-modal.test.tsx` so the lookup stays type-safe
- ignore local `pnpm-workspace.yaml` workspace config files

Verification:
- `cd apps/mobile && bun run test -- components/daily-review-modal.test.tsx`
- `cd apps/mobile && bunx tsc --noEmit`
