### PR TITLE
fix(desktop): persist sandbox access to iCloud Drive sync path across…

### DIFF
--- a/apps/desktop/src-tauri/Entitlements.mas.plist
+++ b/apps/desktop/src-tauri/Entitlements.mas.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
     <key>com.apple.security.network.client</key>

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -5,9 +5,14 @@ fn main() {
       .file("src/macos_eventkit_bridge.m")
       .flag("-fobjc-arc")
       .compile("mindwtr_macos_eventkit_bridge");
+    cc::Build::new()
+      .file("src/macos_sandbox_bridge.m")
+      .flag("-fobjc-arc")
+      .compile("mindwtr_macos_sandbox_bridge");
     println!("cargo:rustc-link-lib=framework=Foundation");
     println!("cargo:rustc-link-lib=framework=EventKit");
     println!("cargo:rerun-if-changed=src/macos_eventkit_bridge.m");
+    println!("cargo:rerun-if-changed=src/macos_sandbox_bridge.m");
   }
 
   tauri_build::build()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ use tauri::menu::{Menu, MenuItem};
 use tauri::path::BaseDirectory;
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
+use tauri_plugin_fs::FsExt;
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 use time::OffsetDateTime;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
@@ -261,6 +262,7 @@ struct LegacyAppConfigJson {
 #[derive(Debug, Default, Clone)]
 struct AppConfigToml {
     sync_path: Option<String>,
+    sync_path_bookmark: Option<String>,
     sync_backend: Option<String>,
     webdav_url: Option<String>,
     webdav_username: Option<String>,
@@ -340,6 +342,9 @@ unsafe extern "C" {
         range_end: *const c_char,
     ) -> *mut c_char;
     fn mindwtr_macos_calendar_free_string(value: *mut c_char);
+    fn mindwtr_macos_create_security_bookmark(path_cstr: *const c_char) -> *mut c_char;
+    fn mindwtr_macos_resolve_security_bookmark(base64_cstr: *const c_char) -> *mut c_char;
+    fn mindwtr_macos_free_bookmark_string(ptr: *mut c_char);
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2229,6 +2234,8 @@ fn read_config_toml(path: &Path) -> AppConfigToml {
         let value = value.trim();
         if key == "sync_path" {
             config.sync_path = parse_toml_string_value(value);
+        } else if key == "sync_path_bookmark" {
+            config.sync_path_bookmark = parse_toml_string_value(value);
         } else if key == "sync_backend" {
             config.sync_backend = parse_toml_string_value(value);
         } else if key == "webdav_url" {
@@ -2318,6 +2325,12 @@ fn write_config_toml_with_header(
             serialize_toml_string_value(sync_path)
         ));
     }
+    if let Some(sync_path_bookmark) = &config.sync_path_bookmark {
+        lines.push(format!(
+            "sync_path_bookmark = {}",
+            serialize_toml_string_value(sync_path_bookmark)
+        ));
+    }
     if let Some(sync_backend) = &config.sync_backend {
         lines.push(format!(
             "sync_backend = {}",
@@ -2397,6 +2410,9 @@ fn write_config_toml_with_header(
 fn merge_config(base: &mut AppConfigToml, overrides: AppConfigToml) {
     if overrides.sync_path.is_some() {
         base.sync_path = overrides.sync_path;
+    }
+    if overrides.sync_path_bookmark.is_some() {
+        base.sync_path_bookmark = overrides.sync_path_bookmark;
     }
     if overrides.sync_backend.is_some() {
         base.sync_backend = overrides.sync_backend;
@@ -2485,6 +2501,7 @@ fn split_config_for_secrets(config: &AppConfigToml) -> (AppConfigToml, AppConfig
 
 fn config_has_values(config: &AppConfigToml) -> bool {
     config.sync_path.is_some()
+        || config.sync_path_bookmark.is_some()
         || config.sync_backend.is_some()
         || config.webdav_url.is_some()
         || config.webdav_username.is_some()
@@ -3601,6 +3618,61 @@ fn resolve_sync_dir(app: &tauri::AppHandle, path: Option<String>) -> Result<Path
     validate_sync_dir(&candidate)
 }
 
+// ---------------------------------------------------------------------------
+// macOS sandbox: security-scoped bookmark helpers
+// ---------------------------------------------------------------------------
+
+/// Create a security-scoped bookmark for `path` so the sandbox remembers
+/// access across app launches.  Returns the base64-encoded bookmark data,
+/// or `None` when not running on macOS or if creation fails.
+#[cfg(target_os = "macos")]
+fn create_sync_path_bookmark(path: &Path) -> Option<String> {
+    let c_path = CString::new(path.to_string_lossy().as_bytes()).ok()?;
+    let raw = unsafe { mindwtr_macos_create_security_bookmark(c_path.as_ptr()) };
+    if raw.is_null() {
+        log::warn!("Failed to create security-scoped bookmark for {:?}", path);
+        return None;
+    }
+    let result = unsafe { CStr::from_ptr(raw) }
+        .to_string_lossy()
+        .to_string();
+    unsafe { mindwtr_macos_free_bookmark_string(raw) };
+    log::info!("Created security-scoped bookmark for {:?}", path);
+    Some(result)
+}
+
+/// Resolve a previously stored bookmark, calling
+/// `startAccessingSecurityScopedResource` so the sandbox grants access.
+/// Returns the resolved path on success.
+#[cfg(target_os = "macos")]
+fn resolve_sync_path_bookmark(base64: &str) -> Option<PathBuf> {
+    let c_b64 = CString::new(base64).ok()?;
+    let raw = unsafe { mindwtr_macos_resolve_security_bookmark(c_b64.as_ptr()) };
+    if raw.is_null() {
+        log::warn!("Failed to resolve security-scoped bookmark");
+        return None;
+    }
+    let resolved = unsafe { CStr::from_ptr(raw) }
+        .to_string_lossy()
+        .to_string();
+    unsafe { mindwtr_macos_free_bookmark_string(raw) };
+    log::info!("Resolved security-scoped bookmark → {resolved}");
+    Some(PathBuf::from(resolved))
+}
+
+/// Add `dir` (and everything beneath it) to the Tauri runtime fs scope so
+/// the TypeScript frontend can use `@tauri-apps/plugin-fs` operations on it.
+fn expand_tauri_fs_scope(app: &tauri::AppHandle, dir: &Path) {
+    if let Err(error) = app.fs_scope().allow_directory(dir, true) {
+        log::warn!(
+            "Failed to expand Tauri fs scope for {:?}: {error}",
+            dir
+        );
+    } else {
+        log::info!("Expanded Tauri fs scope to include {:?}", dir);
+    }
+}
+
 #[tauri::command]
 fn get_sync_path(app: tauri::AppHandle) -> Result<String, String> {
     let config = read_config(&app);
@@ -3631,9 +3703,20 @@ fn set_sync_path(app: tauri::AppHandle, sync_path: String) -> Result<serde_json:
         );
     }
 
+    // Create a security-scoped bookmark so the sandbox remembers this path.
+    #[cfg(target_os = "macos")]
+    let bookmark = create_sync_path_bookmark(&sanitized_path);
+
     let mut config = read_config(&app);
     config.sync_path = Some(sanitized_path.to_string_lossy().to_string());
+    #[cfg(target_os = "macos")]
+    {
+        config.sync_path_bookmark = bookmark;
+    }
     write_config_files(&config_path, &get_secrets_path(&app), &config)?;
+
+    // Expand the Tauri fs scope so the frontend can watch / read / write here.
+    expand_tauri_fs_scope(&app, &sanitized_path);
 
     Ok(serde_json::json!({
         "success": true,
@@ -4730,6 +4813,28 @@ pub fn run() {
         .setup(|app| {
             // Ensure data file exists on startup
             ensure_data_file(&app.handle()).ok();
+
+            // On macOS, restore security-scoped bookmarks so the sandbox
+            // permits access to the user-selected sync folder, then expand the
+            // Tauri fs scope.  On other platforms just expand the scope directly.
+            {
+                let config = read_config(&app.handle());
+
+                #[cfg(target_os = "macos")]
+                if let Some(ref bookmark) = config.sync_path_bookmark {
+                    if let Some(resolved) = resolve_sync_path_bookmark(bookmark) {
+                        expand_tauri_fs_scope(&app.handle(), &resolved);
+                    }
+                }
+
+                if let Some(ref sp) = config.sync_path {
+                    let p = PathBuf::from(sp);
+                    if p.exists() {
+                        expand_tauri_fs_scope(&app.handle(), &p);
+                    }
+                }
+            }
+
             let diagnostics_enabled = diagnostics_enabled();
             let is_windows_store = is_windows_store_install();
             if let Some(window) = app.get_webview_window("main") {

--- a/apps/desktop/src-tauri/src/macos_sandbox_bridge.m
+++ b/apps/desktop/src-tauri/src/macos_sandbox_bridge.m
@@ -1,0 +1,81 @@
+#import <Foundation/Foundation.h>
+#include <stdlib.h>
+#include <string.h>
+
+/// Create a security-scoped bookmark for the given file-system path.
+/// Returns a heap-allocated base64-encoded C string on success, or NULL.
+/// The caller must free the result with `mindwtr_macos_free_bookmark_string`.
+char *mindwtr_macos_create_security_bookmark(const char *path_cstr) {
+    if (!path_cstr) return NULL;
+
+    NSString *pathString = [NSString stringWithUTF8String:path_cstr];
+    NSURL *url = [NSURL fileURLWithPath:pathString isDirectory:YES];
+
+    NSError *error = nil;
+    NSData *bookmarkData =
+        [url bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+          includingResourceValuesForKeys:nil
+                           relativeToURL:nil
+                                   error:&error];
+    if (!bookmarkData) {
+        NSLog(@"[Mindwtr] Failed to create security bookmark for %@: %@",
+              pathString, error);
+        return NULL;
+    }
+
+    NSString *base64 = [bookmarkData base64EncodedStringWithOptions:0];
+    const char *utf8 = [base64 UTF8String];
+    if (!utf8) return NULL;
+
+    return strdup(utf8);
+}
+
+/// Resolve a previously stored security-scoped bookmark (base64-encoded).
+/// On success calls `startAccessingSecurityScopedResource` and returns the
+/// resolved path as a heap-allocated C string.  Returns NULL on failure.
+/// The caller must free the result with `mindwtr_macos_free_bookmark_string`.
+char *mindwtr_macos_resolve_security_bookmark(const char *base64_cstr) {
+    if (!base64_cstr) return NULL;
+
+    NSString *base64String = [NSString stringWithUTF8String:base64_cstr];
+    NSData *bookmarkData =
+        [[NSData alloc] initWithBase64EncodedString:base64String options:0];
+    if (!bookmarkData) {
+        NSLog(@"[Mindwtr] Failed to decode bookmark base64 data");
+        return NULL;
+    }
+
+    BOOL isStale = NO;
+    NSError *error = nil;
+    NSURL *resolvedURL =
+        [NSURL URLByResolvingBookmarkData:bookmarkData
+                                  options:NSURLBookmarkResolutionWithSecurityScope
+                            relativeToURL:nil
+                      bookmarkDataIsStale:&isStale
+                                    error:&error];
+    if (!resolvedURL) {
+        NSLog(@"[Mindwtr] Failed to resolve security bookmark: %@", error);
+        return NULL;
+    }
+
+    if (isStale) {
+        NSLog(@"[Mindwtr] Security bookmark is stale — the app may need to "
+              @"re-select the folder to refresh it");
+    }
+
+    BOOL started = [resolvedURL startAccessingSecurityScopedResource];
+    if (!started) {
+        NSLog(@"[Mindwtr] startAccessingSecurityScopedResource failed for %@",
+              resolvedURL);
+    }
+
+    const char *path = [[resolvedURL path] UTF8String];
+    if (!path) return NULL;
+
+    return strdup(path);
+}
+
+/// Free a string returned by the bookmark helper functions.
+void mindwtr_macos_free_bookmark_string(char *ptr) {
+    free(ptr);
+}


### PR DESCRIPTION

Mac App Store builds run sandboxed, which caused "forbidden path" and "Operation not permitted (os error 1)" errors when accessing iCloud Drive for file sync. The sandbox grants temporary access when the user picks a folder via the dialog, but that access was lost on every restart.

Three fixes:
1. Add com.apple.security.files.bookmarks.app-scope entitlement so the app can persist folder access via security-scoped bookmarks.
2. New ObjC bridge (macos_sandbox_bridge.m) creates an NSURL bookmark when the user sets a sync path and resolves it on startup, calling startAccessingSecurityScopedResource to re-acquire sandbox access.
3. Dynamically expand Tauri's runtime fs scope to include the sync path on startup and when it changes, fixing "forbidden path" errors from the TypeScript fs plugin (watch, mkdir, read).