### PR TITLE
fix(cloudkit): handle missing record types on fresh container

### DIFF
--- a/apps/mobile/lib/cloudkit-sync.ts
+++ b/apps/mobile/lib/cloudkit-sync.ts
@@ -294,13 +294,31 @@ export const subscribeToCloudKitChanges = (onChanged: () => void): (() => void) 
 
 // MARK: - Helpers
 
+/**
+ * Fetch all records of a given type, returning an empty array if CloudKit
+ * reports the record type doesn't exist yet. This happens on a fresh CloudKit
+ * container before any data has been written (record types are created
+ * implicitly on first write, so a background readRemote before the first
+ * manual sync would otherwise throw).
+ */
+async function fetchAllRecordsSafe(recordType: string): Promise<Array<Record<string, unknown>>> {
+    try {
+        return await CloudKitSync!.fetchAllRecords(recordType);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('Did not find record type')) {
+            return [];
+        }
+        throw error;
+    }
+}
+
 async function fullFetch(): Promise<AppData> {
     const [tasks, projects, sections, areas, settingsRecords] = await Promise.all([
-        CloudKitSync!.fetchAllRecords(RECORD_TYPES.task),
-        CloudKitSync!.fetchAllRecords(RECORD_TYPES.project),
-        CloudKitSync!.fetchAllRecords(RECORD_TYPES.section),
-        CloudKitSync!.fetchAllRecords(RECORD_TYPES.area),
-        CloudKitSync!.fetchAllRecords(RECORD_TYPES.settings),
+        fetchAllRecordsSafe(RECORD_TYPES.task),
+        fetchAllRecordsSafe(RECORD_TYPES.project),
+        fetchAllRecordsSafe(RECORD_TYPES.section),
+        fetchAllRecordsSafe(RECORD_TYPES.area),
+        fetchAllRecordsSafe(RECORD_TYPES.settings),
     ]);
 
     // Extract settings from the single settings record


### PR DESCRIPTION
Background sync failed with "Did not find record type" because CloudKit record types are created implicitly on first write. A background readRemote before any manual sync had run would call fetchAllRecords on a container with no schema, causing the error. Treat "Did not find record type" as an empty collection so the sync proceeds, merges local data, and writes it — which creates the record types for all future syncs.