### PR TITLE
fix(desktop): persist area collapse state across navigation

### DIFF
--- a/apps/desktop/src/components/views/ProjectsView.tsx
+++ b/apps/desktop/src/components/views/ProjectsView.tsx
@@ -22,6 +22,29 @@ import { useProjectsViewStore } from './projects/useProjectsViewStore';
 import { splitProjectsForSidebar } from './projects/project-sidebar-grouping';
 import { useConfirmDialog } from '../../hooks/useConfirmDialog';
 
+const COLLAPSED_AREAS_STORAGE_KEY = 'mindwtr:projects:collapsedAreas';
+
+function loadCollapsedAreas(): Record<string, boolean> {
+    if (typeof window === 'undefined') return {};
+    try {
+        const raw = window.localStorage.getItem(COLLAPSED_AREAS_STORAGE_KEY);
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+        return {};
+    }
+}
+
+function saveCollapsedAreas(state: Record<string, boolean>) {
+    if (typeof window === 'undefined') return;
+    try {
+        window.localStorage.setItem(COLLAPSED_AREAS_STORAGE_KEY, JSON.stringify(state));
+    } catch {
+        // storage unavailable — fall back to in-memory only
+    }
+}
+
 export function ProjectsView() {
     const perf = usePerformanceMonitor('ProjectsView');
     const {
@@ -69,7 +92,8 @@ export function ProjectsView() {
     const [newProjectTitle, setNewProjectTitle] = useState('');
     const [showDeferredProjects, setShowDeferredProjects] = useState(false);
     const [showArchivedProjects, setShowArchivedProjects] = useState(false);
-    const [collapsedAreas, setCollapsedAreas] = useState<Record<string, boolean>>({});
+    const [collapsedAreas, setCollapsedAreas] = useState<Record<string, boolean>>(loadCollapsedAreas);
+    useEffect(() => { saveCollapsedAreas(collapsedAreas); }, [collapsedAreas]);
     const [showAreaManager, setShowAreaManager] = useState(false);
     const [newAreaName, setNewAreaName] = useState('');
     const [newAreaColor, setNewAreaColor] = useState(DEFAULT_AREA_COLOR);


### PR DESCRIPTION
## Summary
- Area collapsed/expanded state in the projects sidebar was stored in component state and silently reset every time you navigated away from the Projects view
- Now reads the initial state from `localStorage` on mount and writes back on every toggle, so the layout is preserved between visits
- Follows the same pattern already used for sidebar section collapse state in `Layout.tsx`
- Storage key: `mindwtr:projects:collapsedAreas`

## Test plan
- [ ] Open Projects view, collapse one or more areas
- [ ] Navigate to another view (Inbox, Next Actions, etc.) and return to Projects
- [ ] Confirm the areas are still in the collapsed state you left them
- [ ] Confirm expanding an area and navigating away also persists correctly
- [ ] Verify no regressions in area drag-to-reorder behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)