### PR TITLE
feat(mobile): push tasks with due dates to a native device calendar

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -627,6 +627,21 @@ pub fn run() {
                         expand_tauri_fs_scope(&app.handle(), &p);
                     }
                 }
+
+                // Also expand scope for the Obsidian vault path, which may be
+                // inside iCloud Drive or another location not covered at runtime.
+                if let Some(ref raw_obsidian) = config.obsidian_config {
+                    #[derive(serde::Deserialize, Default)]
+                    struct VaultPathOnly { vault_path: Option<String> }
+                    if let Ok(parsed) = serde_json::from_str::<VaultPathOnly>(raw_obsidian) {
+                        if let Some(vp) = parsed.vault_path {
+                            let p = PathBuf::from(vp.trim());
+                            if p.exists() {
+                                expand_tauri_fs_scope(&app.handle(), &p);
+                            }
+                        }
+                    }
+                }
             }
 
             let diagnostics_enabled = diagnostics_enabled();

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -31,7 +31,9 @@
       "package": "tech.dongdongbh.mindwtr",
       "permissions": [
         "RECORD_AUDIO",
-        "POST_NOTIFICATIONS"
+        "POST_NOTIFICATIONS",
+        "READ_CALENDAR",
+        "WRITE_CALENDAR"
       ],
       "blockedPermissions": [
         "android.permission.CAMERA",

--- a/apps/mobile/app/_effects/use-root-layout-sync-effects.ts
+++ b/apps/mobile/app/_effects/use-root-layout-sync-effects.ts
@@ -6,6 +6,7 @@ import { flushPendingSave, useTaskStore } from '@mindwtr/core';
 
 import type { ToastOptions } from '@/contexts/toast-context';
 import { getNotificationPermissionStatus, startMobileNotifications, stopMobileNotifications } from '@/lib/notification-service';
+import { getCalendarPushEnabled, runFullCalendarSync, startCalendarPushSync, stopCalendarPushSync } from '@/lib/calendar-push-sync';
 import { abortMobileSync, performMobileSync } from '@/lib/sync-service';
 import { classifySyncFailure, coerceSupportedBackend, isLikelyOfflineSyncError, resolveBackend, type SyncBackend } from '@/lib/sync-service-utils';
 import { SYNC_BACKEND_KEY } from '@/lib/sync-constants';
@@ -401,6 +402,20 @@ export function useRootLayoutSyncEffects({
         });
 
         return () => unsubscribe();
+    }, []);
+
+    // Start calendar push sync on mount if enabled; stop on unmount.
+    useEffect(() => {
+        let stopSync: (() => void) | null = null;
+        void getCalendarPushEnabled().then((enabled) => {
+            if (!enabled) return;
+            stopSync = startCalendarPushSync();
+            void runFullCalendarSync();
+        });
+        return () => {
+            stopSync?.();
+            stopCalendarPushSync();
+        };
     }, []);
 
     return { requestSync };

--- a/apps/mobile/components/settings/calendar-settings-screen.tsx
+++ b/apps/mobile/components/settings/calendar-settings-screen.tsx
@@ -99,6 +99,11 @@ export function CalendarSettingsScreen() {
     };
 
     const handleDeleteMindwtrCalendar = async () => {
+        // Disable push sync first so the calendar is not recreated on the next
+        // startup or task change.
+        await setCalendarPushEnabled(false);
+        setCalendarPushEnabledState(false);
+        stopCalendarPushSync();
         await deleteMindwtrCalendar();
         showToast({
             title: localize('Calendar deleted', '日历已删除'),

--- a/apps/mobile/components/settings/calendar-settings-screen.tsx
+++ b/apps/mobile/components/settings/calendar-settings-screen.tsx
@@ -16,6 +16,16 @@ import {
     type SystemCalendarInfo,
     type SystemCalendarPermissionStatus,
 } from '@/lib/external-calendar';
+import {
+    deleteMindwtrCalendar,
+    getCalendarPushEnabled,
+    getCalendarWritePermissionStatus,
+    requestCalendarWritePermission,
+    runFullCalendarSync,
+    setCalendarPushEnabled,
+    startCalendarPushSync,
+    stopCalendarPushSync,
+} from '@/lib/calendar-push-sync';
 import { useToast } from '@/contexts/toast-context';
 import { maskCalendarUrl } from '@/lib/settings-utils';
 import { useThemeColors } from '@/hooks/use-theme-colors';
@@ -39,6 +49,64 @@ export function CalendarSettingsScreen() {
     const [systemCalendarPermission, setSystemCalendarPermission] = useState<SystemCalendarPermissionStatus>('undetermined');
     const [systemCalendars, setSystemCalendars] = useState<SystemCalendarInfo[]>([]);
     const [isSystemCalendarLoading, setIsSystemCalendarLoading] = useState(false);
+
+    // Push-to-calendar state
+    const [calendarPushEnabled, setCalendarPushEnabledState] = useState(false);
+    const [calendarPushPermission, setCalendarPushPermission] = useState<'granted' | 'denied' | 'undetermined'>('undetermined');
+
+    useEffect(() => {
+        void (async () => {
+            const [enabled, permission] = await Promise.all([
+                getCalendarPushEnabled(),
+                getCalendarWritePermissionStatus(),
+            ]);
+            setCalendarPushEnabledState(enabled);
+            setCalendarPushPermission(permission);
+        })();
+    }, []);
+
+    const handleToggleCalendarPush = async (enabled: boolean) => {
+        if (enabled) {
+            const granted = calendarPushPermission === 'granted'
+                ? true
+                : await requestCalendarWritePermission();
+            if (!granted) {
+                setCalendarPushPermission('denied');
+                showToast({
+                    title: localize('Permission Required', '需要权限'),
+                    message: localize('Calendar access is required to push tasks to your calendar.', '需要日历访问权限才能将任务推送到您的日历。'),
+                    tone: 'warning',
+                    durationMs: 4200,
+                });
+                return;
+            }
+            setCalendarPushPermission('granted');
+            await setCalendarPushEnabled(true);
+            setCalendarPushEnabledState(true);
+            startCalendarPushSync();
+            void runFullCalendarSync();
+        } else {
+            await setCalendarPushEnabled(false);
+            setCalendarPushEnabledState(false);
+            stopCalendarPushSync();
+            showToast({
+                title: localize('Calendar sync disabled', '日历同步已禁用'),
+                message: localize('Tasks will no longer be pushed to your calendar. Existing events were kept.', '任务将不再推送到您的日历。已创建的日程已保留。'),
+                tone: 'info',
+                durationMs: 4200,
+            });
+        }
+    };
+
+    const handleDeleteMindwtrCalendar = async () => {
+        await deleteMindwtrCalendar();
+        showToast({
+            title: localize('Calendar deleted', '日历已删除'),
+            message: localize('The Mindwtr calendar and all its events have been removed.', 'Mindwtr 日历及其所有日程已删除。'),
+            tone: 'success',
+            durationMs: 3500,
+        });
+    };
 
     const loadSystemCalendarState = useCallback(async (requestAccess = false) => {
         setIsSystemCalendarLoading(true);
@@ -222,6 +290,52 @@ export function CalendarSettingsScreen() {
             <SubHeader title={t('settings.calendar')} />
             <ScrollView style={styles.scrollView} contentContainerStyle={scrollContentStyle}>
                 <Text style={[styles.description, { color: tc.secondaryText }]}>{t('settings.calendarDesc')}</Text>
+
+                {/* Push tasks to calendar */}
+                <View style={[styles.settingCard, { backgroundColor: tc.cardBg, marginBottom: 16 }]}>
+                    <View style={styles.settingRow}>
+                        <View style={styles.settingInfo}>
+                            <Text style={[styles.settingLabel, { color: tc.text }]}>
+                                {localize('Push tasks to calendar', '将任务推送到日历')}
+                            </Text>
+                            <Text style={[styles.settingDescription, { color: tc.secondaryText }]}>
+                                {localize(
+                                    'Tasks with due dates are added to a dedicated "Mindwtr" calendar on your device.',
+                                    '有截止日期的任务将添加到设备上专用的"Mindwtr"日历中。'
+                                )}
+                            </Text>
+                        </View>
+                        <Switch
+                            value={calendarPushEnabled}
+                            onValueChange={(v) => void handleToggleCalendarPush(v)}
+                            trackColor={{ false: '#767577', true: '#3B82F6' }}
+                        />
+                    </View>
+
+                    {calendarPushEnabled && calendarPushPermission === 'denied' && (
+                        <View style={{ marginTop: 12, paddingTop: 12, borderTopWidth: 1, borderTopColor: tc.border }}>
+                            <Text style={[styles.settingDescription, { color: tc.secondaryText }]}>
+                                {localize(
+                                    'Calendar access was denied. Please grant access in Settings.',
+                                    '日历访问被拒绝。请在设置中授予访问权限。'
+                                )}
+                            </Text>
+                        </View>
+                    )}
+
+                    {calendarPushEnabled && calendarPushPermission === 'granted' && (
+                        <View style={{ marginTop: 12, paddingTop: 12, borderTopWidth: 1, borderTopColor: tc.border }}>
+                            <TouchableOpacity
+                                onPress={() => void handleDeleteMindwtrCalendar()}
+                                style={{ alignSelf: 'flex-start' }}
+                            >
+                                <Text style={{ color: '#EF4444', fontSize: 13, fontWeight: '600' }}>
+                                    {localize('Delete Mindwtr calendar…', '删除 Mindwtr 日历…')}
+                                </Text>
+                            </TouchableOpacity>
+                        </View>
+                    )}
+                </View>
 
                 <View style={[styles.settingCard, { backgroundColor: tc.cardBg }]}>
                     <View style={styles.settingRow}>

--- a/apps/mobile/lib/calendar-push-sync.ts
+++ b/apps/mobile/lib/calendar-push-sync.ts
@@ -9,7 +9,7 @@
 import * as Calendar from 'expo-calendar';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useTaskStore, type Task } from '@mindwtr/core';
+import { safeParseDate, useTaskStore, type Task } from '@mindwtr/core';
 
 import { logInfo, logWarn, logError } from './app-log';
 import {
@@ -149,13 +149,16 @@ export const deleteMindwtrCalendar = async (): Promise<void> => {
 // MARK: - Per-task sync
 
 function buildEventDetails(task: Task) {
-    const dueDate = new Date(task.dueDate!);
-    // For all-day events, end at 23:59:59 on the same day
-    const endDate = new Date(dueDate);
+    // safeParseDate parses YYYY-MM-DD as local midnight, avoiding the UTC
+    // shift that `new Date(dateString)` produces for date-only strings.
+    const parsed = safeParseDate(task.dueDate);
+    const startDate = parsed ?? new Date();
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = new Date(startDate);
     endDate.setHours(23, 59, 59, 999);
     return {
         title: task.title,
-        startDate: dueDate,
+        startDate,
         endDate,
         allDay: true,
         notes: task.description ?? '',

--- a/apps/mobile/lib/calendar-push-sync.ts
+++ b/apps/mobile/lib/calendar-push-sync.ts
@@ -16,6 +16,7 @@ import {
     getCalendarSyncEntry,
     upsertCalendarSyncEntry,
     deleteCalendarSyncEntry,
+    getAllCalendarSyncEntries,
 } from './storage-adapter';
 
 // MARK: - Constants
@@ -79,27 +80,43 @@ export const ensureMindwtrCalendar = async (): Promise<string | null> => {
             // Calendar was deleted externally — fall through to recreate
         }
 
-        // Find best available calendar source
-        const sources = await Calendar.getSourcesAsync();
-        const source =
-            sources.find((s) => s.type === Calendar.SourceType.LOCAL) ??
-            sources.find((s) => s.type === Calendar.SourceType.CALDAV) ??
-            sources[0];
+        let calendarDetails: Parameters<typeof Calendar.createCalendarAsync>[0];
 
-        if (!source) {
-            void logWarn('No calendar source available; cannot create Mindwtr calendar', {
-                scope: 'calendar-push',
-            });
-            return null;
+        if (Platform.OS === 'android') {
+            // Android does not use sources; needs name, ownerAccount, and accessLevel
+            calendarDetails = {
+                title: 'Mindwtr',
+                color: '#3B82F6',
+                entityType: Calendar.EntityTypes.EVENT,
+                name: 'mindwtr',
+                ownerAccount: 'mindwtr',
+                accessLevel: Calendar.CalendarAccessLevel.OWNER,
+            };
+        } else {
+            // iOS requires a source
+            const sources = await Calendar.getSourcesAsync();
+            const source =
+                sources.find((s) => s.type === Calendar.SourceType.LOCAL) ??
+                sources.find((s) => s.type === Calendar.SourceType.CALDAV) ??
+                sources[0];
+
+            if (!source) {
+                void logWarn('No calendar source available; cannot create Mindwtr calendar', {
+                    scope: 'calendar-push',
+                });
+                return null;
+            }
+
+            calendarDetails = {
+                title: 'Mindwtr',
+                color: '#3B82F6',
+                entityType: Calendar.EntityTypes.EVENT,
+                sourceId: source.id,
+                source,
+            };
         }
 
-        const newId = await Calendar.createCalendarAsync({
-            title: 'Mindwtr',
-            color: '#3B82F6',
-            entityType: Calendar.EntityTypes.EVENT,
-            sourceId: source.id,
-            source,
-        });
+        const newId = await Calendar.createCalendarAsync(calendarDetails);
 
         await setStoredCalendarId(newId);
         void logInfo('Created Mindwtr calendar', {
@@ -156,9 +173,13 @@ async function removeTaskFromCalendar(taskId: string): Promise<void> {
     await deleteCalendarSyncEntry(taskId, PLATFORM);
 }
 
+/** Returns true for tasks that should not have a calendar event. */
+function shouldRemoveFromCalendar(task: Task): boolean {
+    return !task.dueDate || !!task.deletedAt || task.status === 'done' || task.status === 'archived';
+}
+
 async function syncTaskToCalendar(task: Task, calendarId: string): Promise<void> {
-    // Remove from calendar if no due date or soft-deleted
-    if (!task.dueDate || task.deletedAt) {
+    if (shouldRemoveFromCalendar(task)) {
         await removeTaskFromCalendar(task.id);
         return;
     }
@@ -202,14 +223,30 @@ export const runFullCalendarSync = async (): Promise<void> => {
     if (!calendarId) return;
 
     const { tasks } = useTaskStore.getState();
+
+    // Sync all tasks currently in the store
     const results = await Promise.allSettled(
         tasks.map((task) => syncTaskToCalendar(task, calendarId))
     );
 
+    // Reconcile: remove stale calendar_sync entries for tasks that are no
+    // longer in the store or that should not have an event (completed between
+    // sessions, archived, etc.)
+    const activeEventIds = new Set(
+        tasks.filter((t) => !shouldRemoveFromCalendar(t)).map((t) => t.id)
+    );
+    const syncedEntries = await getAllCalendarSyncEntries(PLATFORM);
+    const staleEntries = syncedEntries.filter((e) => !activeEventIds.has(e.taskId));
+    await Promise.allSettled(staleEntries.map((e) => removeTaskFromCalendar(e.taskId)));
+
     const failed = results.filter((r) => r.status === 'rejected').length;
     void logInfo('Full calendar sync complete', {
         scope: 'calendar-push',
-        extra: { total: String(tasks.length), failed: String(failed) },
+        extra: {
+            total: String(tasks.length),
+            failed: String(failed),
+            stale: String(staleEntries.length),
+        },
     });
 };
 
@@ -272,6 +309,7 @@ export const startCalendarPushSync = (): (() => void) => {
                 prev.updatedAt !== task.updatedAt ||
                 prev.dueDate !== task.dueDate ||
                 prev.deletedAt !== task.deletedAt ||
+                prev.status !== task.status ||
                 prev.title !== task.title
             ) {
                 changedIds.push(task.id);

--- a/apps/mobile/lib/calendar-push-sync.ts
+++ b/apps/mobile/lib/calendar-push-sync.ts
@@ -1,0 +1,312 @@
+/**
+ * Calendar push sync service.
+ *
+ * One-way push of tasks with due dates into a dedicated "Mindwtr" calendar on
+ * the device (iOS EventKit via expo-calendar). Creates, updates, or removes
+ * calendar events as task due dates change. Mapping between task IDs and
+ * calendar event IDs is persisted in the SQLite calendar_sync table.
+ */
+import * as Calendar from 'expo-calendar';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useTaskStore, type Task } from '@mindwtr/core';
+
+import { logInfo, logWarn, logError } from './app-log';
+import {
+    getCalendarSyncEntry,
+    upsertCalendarSyncEntry,
+    deleteCalendarSyncEntry,
+} from './storage-adapter';
+
+// MARK: - Constants
+
+const CALENDAR_PUSH_ENABLED_KEY = 'mindwtr:calendar-push-sync:enabled';
+const CALENDAR_ID_KEY = 'mindwtr:calendar-push-sync:calendar-id';
+const PLATFORM = Platform.OS;
+const SYNC_DEBOUNCE_MS = 2500;
+
+// MARK: - Settings
+
+export const getCalendarPushEnabled = async (): Promise<boolean> => {
+    const val = await AsyncStorage.getItem(CALENDAR_PUSH_ENABLED_KEY);
+    return val === '1';
+};
+
+export const setCalendarPushEnabled = async (enabled: boolean): Promise<void> => {
+    await AsyncStorage.setItem(CALENDAR_PUSH_ENABLED_KEY, enabled ? '1' : '0');
+};
+
+// MARK: - Permission
+
+export const requestCalendarWritePermission = async (): Promise<boolean> => {
+    try {
+        const { status } = await Calendar.requestCalendarPermissionsAsync();
+        return status === 'granted';
+    } catch {
+        return false;
+    }
+};
+
+export const getCalendarWritePermissionStatus = async (): Promise<'granted' | 'denied' | 'undetermined'> => {
+    try {
+        const { status } = await Calendar.getCalendarPermissionsAsync();
+        if (status === 'granted') return 'granted';
+        if (status === 'denied') return 'denied';
+        return 'undetermined';
+    } catch {
+        return 'undetermined';
+    }
+};
+
+// MARK: - Managed Calendar
+
+const getStoredCalendarId = (): Promise<string | null> =>
+    AsyncStorage.getItem(CALENDAR_ID_KEY);
+
+const setStoredCalendarId = (id: string): Promise<void> =>
+    AsyncStorage.setItem(CALENDAR_ID_KEY, id);
+
+/**
+ * Returns the ID of the managed "Mindwtr" calendar, creating it if needed.
+ * Returns null if the calendar cannot be created (e.g. no permission, no source).
+ */
+export const ensureMindwtrCalendar = async (): Promise<string | null> => {
+    try {
+        const storedId = await getStoredCalendarId();
+        if (storedId) {
+            const allCalendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
+            if (allCalendars.some((c) => c.id === storedId)) return storedId;
+            // Calendar was deleted externally — fall through to recreate
+        }
+
+        // Find best available calendar source
+        const sources = await Calendar.getSourcesAsync();
+        const source =
+            sources.find((s) => s.type === Calendar.SourceType.LOCAL) ??
+            sources.find((s) => s.type === Calendar.SourceType.CALDAV) ??
+            sources[0];
+
+        if (!source) {
+            void logWarn('No calendar source available; cannot create Mindwtr calendar', {
+                scope: 'calendar-push',
+            });
+            return null;
+        }
+
+        const newId = await Calendar.createCalendarAsync({
+            title: 'Mindwtr',
+            color: '#3B82F6',
+            entityType: Calendar.EntityTypes.EVENT,
+            sourceId: source.id,
+            source,
+        });
+
+        await setStoredCalendarId(newId);
+        void logInfo('Created Mindwtr calendar', {
+            scope: 'calendar-push',
+            extra: { calendarId: newId },
+        });
+        return newId;
+    } catch (error) {
+        void logError(error, { scope: 'calendar-push', extra: { operation: 'ensureMindwtrCalendar' } });
+        return null;
+    }
+};
+
+/**
+ * Deletes the managed Mindwtr calendar and removes the stored ID.
+ * Called when the user disables calendar push sync and chooses to clean up.
+ */
+export const deleteMindwtrCalendar = async (): Promise<void> => {
+    const storedId = await getStoredCalendarId();
+    if (!storedId) return;
+    try {
+        await Calendar.deleteCalendarAsync(storedId);
+    } catch {
+        // Already deleted or not found — ignore
+    }
+    await AsyncStorage.removeItem(CALENDAR_ID_KEY);
+    void logInfo('Deleted Mindwtr calendar', { scope: 'calendar-push' });
+};
+
+// MARK: - Per-task sync
+
+function buildEventDetails(task: Task) {
+    const dueDate = new Date(task.dueDate!);
+    // For all-day events, end at 23:59:59 on the same day
+    const endDate = new Date(dueDate);
+    endDate.setHours(23, 59, 59, 999);
+    return {
+        title: task.title,
+        startDate: dueDate,
+        endDate,
+        allDay: true,
+        notes: task.description ?? '',
+    };
+}
+
+async function removeTaskFromCalendar(taskId: string): Promise<void> {
+    const entry = await getCalendarSyncEntry(taskId, PLATFORM);
+    if (!entry) return;
+    try {
+        await Calendar.deleteEventAsync(entry.calendarEventId);
+    } catch {
+        // Event may already be deleted
+    }
+    await deleteCalendarSyncEntry(taskId, PLATFORM);
+}
+
+async function syncTaskToCalendar(task: Task, calendarId: string): Promise<void> {
+    // Remove from calendar if no due date or soft-deleted
+    if (!task.dueDate || task.deletedAt) {
+        await removeTaskFromCalendar(task.id);
+        return;
+    }
+
+    const details = buildEventDetails(task);
+    const existing = await getCalendarSyncEntry(task.id, PLATFORM);
+
+    if (existing && existing.calendarId === calendarId) {
+        try {
+            await Calendar.updateEventAsync(existing.calendarEventId, details);
+            await upsertCalendarSyncEntry({
+                taskId: task.id,
+                calendarEventId: existing.calendarEventId,
+                calendarId,
+                platform: PLATFORM,
+                lastSyncedAt: new Date().toISOString(),
+            });
+            return;
+        } catch {
+            // Event deleted externally — fall through to create
+        }
+    }
+
+    const eventId = await Calendar.createEventAsync(calendarId, { ...details, calendarId });
+    await upsertCalendarSyncEntry({
+        taskId: task.id,
+        calendarEventId: eventId,
+        calendarId,
+        platform: PLATFORM,
+        lastSyncedAt: new Date().toISOString(),
+    });
+}
+
+// MARK: - Full sync
+
+export const runFullCalendarSync = async (): Promise<void> => {
+    const enabled = await getCalendarPushEnabled();
+    if (!enabled) return;
+
+    const calendarId = await ensureMindwtrCalendar();
+    if (!calendarId) return;
+
+    const { tasks } = useTaskStore.getState();
+    const results = await Promise.allSettled(
+        tasks.map((task) => syncTaskToCalendar(task, calendarId))
+    );
+
+    const failed = results.filter((r) => r.status === 'rejected').length;
+    void logInfo('Full calendar sync complete', {
+        scope: 'calendar-push',
+        extra: { total: String(tasks.length), failed: String(failed) },
+    });
+};
+
+// MARK: - Debounced partial sync
+
+let syncDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const scheduleSyncDebounced = (taskIds: string[]): void => {
+    if (syncDebounceTimer) clearTimeout(syncDebounceTimer);
+    syncDebounceTimer = setTimeout(() => {
+        syncDebounceTimer = null;
+        void runPartialCalendarSync(taskIds);
+    }, SYNC_DEBOUNCE_MS);
+};
+
+const runPartialCalendarSync = async (taskIds: string[]): Promise<void> => {
+    const enabled = await getCalendarPushEnabled();
+    if (!enabled) return;
+
+    const calendarId = await ensureMindwtrCalendar();
+    if (!calendarId) return;
+
+    const { tasks } = useTaskStore.getState();
+    const targets = tasks.filter((t) => taskIds.includes(t.id));
+
+    // Also handle tasks that were removed from the store (deleted)
+    const storeIds = new Set(tasks.map((t) => t.id));
+    const removedIds = taskIds.filter((id) => !storeIds.has(id));
+
+    await Promise.allSettled([
+        ...targets.map((t) => syncTaskToCalendar(t, calendarId)),
+        ...removedIds.map((id) => removeTaskFromCalendar(id)),
+    ]);
+};
+
+// MARK: - Store subscription
+
+let unsubscribeStore: (() => void) | null = null;
+
+/**
+ * Starts watching the task store for changes and syncing due-date tasks to
+ * the device calendar. Returns an unsubscribe function.
+ */
+export const startCalendarPushSync = (): (() => void) => {
+    if (unsubscribeStore) return unsubscribeStore;
+
+    let previousTaskMap = new Map(
+        useTaskStore.getState().tasks.map((t) => [t.id, t])
+    );
+
+    unsubscribeStore = useTaskStore.subscribe((state) => {
+        const changedIds: string[] = [];
+        const currentMap = new Map(state.tasks.map((t) => [t.id, t]));
+
+        // Changed or new tasks
+        for (const task of state.tasks) {
+            const prev = previousTaskMap.get(task.id);
+            if (
+                !prev ||
+                prev.updatedAt !== task.updatedAt ||
+                prev.dueDate !== task.dueDate ||
+                prev.deletedAt !== task.deletedAt ||
+                prev.title !== task.title
+            ) {
+                changedIds.push(task.id);
+            }
+        }
+
+        // Tasks removed from store entirely
+        for (const id of previousTaskMap.keys()) {
+            if (!currentMap.has(id)) {
+                changedIds.push(id);
+            }
+        }
+
+        previousTaskMap = currentMap;
+
+        if (changedIds.length > 0) {
+            scheduleSyncDebounced(changedIds);
+        }
+    });
+
+    return () => {
+        unsubscribeStore?.();
+        unsubscribeStore = null;
+        if (syncDebounceTimer) {
+            clearTimeout(syncDebounceTimer);
+            syncDebounceTimer = null;
+        }
+    };
+};
+
+export const stopCalendarPushSync = (): void => {
+    unsubscribeStore?.();
+    unsubscribeStore = null;
+    if (syncDebounceTimer) {
+        clearTimeout(syncDebounceTimer);
+        syncDebounceTimer = null;
+    }
+};

--- a/apps/mobile/lib/storage-adapter.ts
+++ b/apps/mobile/lib/storage-adapter.ts
@@ -1,4 +1,4 @@
-import { AppData, SqliteAdapter, searchAll, type SqliteClient, StorageAdapter } from '@mindwtr/core';
+import { AppData, SqliteAdapter, searchAll, type SqliteClient, type CalendarSyncEntry, StorageAdapter } from '@mindwtr/core';
 import { Platform } from 'react-native';
 import Constants from 'expo-constants';
 
@@ -544,3 +544,25 @@ const createStorage = (): StorageAdapter => {
 };
 
 export const mobileStorage = createStorage();
+
+// MARK: - Calendar Sync SQLite helpers
+
+export const getCalendarSyncEntry = async (taskId: string, platform: string) => {
+    const { adapter } = await getSqliteState();
+    return adapter.getCalendarSyncEntry(taskId, platform);
+};
+
+export const upsertCalendarSyncEntry = async (entry: CalendarSyncEntry) => {
+    const { adapter } = await getSqliteState();
+    return adapter.upsertCalendarSyncEntry(entry);
+};
+
+export const deleteCalendarSyncEntry = async (taskId: string, platform: string) => {
+    const { adapter } = await getSqliteState();
+    return adapter.deleteCalendarSyncEntry(taskId, platform);
+};
+
+export const getAllCalendarSyncEntries = async (platform: string) => {
+    const { adapter } = await getSqliteState();
+    return adapter.getAllCalendarSyncEntries(platform);
+};

--- a/apps/mobile/tests/calendar-push-sync.test.ts
+++ b/apps/mobile/tests/calendar-push-sync.test.ts
@@ -80,6 +80,16 @@ vi.mock('@mindwtr/core', () => ({
         getState: mockGetState,
         subscribe: vi.fn(() => () => {}),
     },
+    // Real implementation: parses YYYY-MM-DD as LOCAL midnight (not UTC).
+    safeParseDate: (dateStr: string | null | undefined): Date | null => {
+        if (!dateStr) return null;
+        const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(dateStr);
+        if (match) {
+            return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+        }
+        const d = new Date(dateStr);
+        return isNaN(d.getTime()) ? null : d;
+    },
 }));
 
 vi.mock('@/lib/storage-adapter', () => ({
@@ -168,6 +178,34 @@ describe('ensureMindwtrCalendar', () => {
         expect(mockCreateCalendarAsync).toHaveBeenCalledOnce();
         expect(id).toBe('cal-2');
         expect(mockSetItem).toHaveBeenCalledWith('mindwtr:calendar-push-sync:calendar-id', 'cal-2');
+    });
+});
+
+describe('buildEventDetails — date-only due date stays on correct local day', () => {
+    it('does not shift a YYYY-MM-DD due date to the previous day', async () => {
+        setupEnabled();
+        // Use a fixed date-only string — no time, no timezone suffix.
+        // new Date('2026-04-20') parses as UTC midnight and shifts to Apr 19
+        // in US time zones; safeParseDate('2026-04-20') must produce Apr 20.
+        const task = makeTask({ dueDate: '2026-04-20' });
+        mockGetState.mockReturnValue({ tasks: [task] });
+        mockGetCalendarSyncEntry.mockResolvedValue(null);
+        mockGetAllCalendarSyncEntries.mockResolvedValue([]);
+
+        await runFullCalendarSync();
+
+        expect(mockCreateEventAsync).toHaveBeenCalledOnce();
+        const [, eventData] = mockCreateEventAsync.mock.calls[0] as [string, { startDate: Date; endDate: Date; allDay: boolean }];
+
+        expect(eventData.allDay).toBe(true);
+        expect(eventData.startDate.getFullYear()).toBe(2026);
+        expect(eventData.startDate.getMonth()).toBe(3); // April (0-indexed)
+        expect(eventData.startDate.getDate()).toBe(20);
+        expect(eventData.startDate.getHours()).toBe(0);
+
+        expect(eventData.endDate.getFullYear()).toBe(2026);
+        expect(eventData.endDate.getMonth()).toBe(3);
+        expect(eventData.endDate.getDate()).toBe(20);
     });
 });
 

--- a/apps/mobile/tests/calendar-push-sync.test.ts
+++ b/apps/mobile/tests/calendar-push-sync.test.ts
@@ -195,7 +195,8 @@ describe('buildEventDetails — date-only due date stays on correct local day', 
         await runFullCalendarSync();
 
         expect(mockCreateEventAsync).toHaveBeenCalledOnce();
-        const [, eventData] = mockCreateEventAsync.mock.calls[0] as [string, { startDate: Date; endDate: Date; allDay: boolean }];
+        const call = mockCreateEventAsync.mock.calls[0] as unknown as [string, { startDate: Date; endDate: Date; allDay: boolean }];
+        const [, eventData] = call;
 
         expect(eventData.allDay).toBe(true);
         expect(eventData.startDate.getFullYear()).toBe(2026);

--- a/apps/mobile/tests/calendar-push-sync.test.ts
+++ b/apps/mobile/tests/calendar-push-sync.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be set up before any imports that reference them
+// ---------------------------------------------------------------------------
+
+const {
+    mockGetItem,
+    mockSetItem,
+    mockRemoveItem,
+    mockGetCalendarsAsync,
+    mockGetSourcesAsync,
+    mockCreateCalendarAsync,
+    mockDeleteCalendarAsync,
+    mockCreateEventAsync,
+    mockUpdateEventAsync,
+    mockDeleteEventAsync,
+    mockGetCalendarSyncEntry,
+    mockUpsertCalendarSyncEntry,
+    mockDeleteCalendarSyncEntry,
+    mockGetAllCalendarSyncEntries,
+    mockGetState,
+    mockLogInfo,
+    mockLogWarn,
+    mockLogError,
+} = vi.hoisted(() => ({
+    mockGetItem: vi.fn(async () => null as string | null),
+    mockSetItem: vi.fn(async () => {}),
+    mockRemoveItem: vi.fn(async () => {}),
+    mockGetCalendarsAsync: vi.fn(async () => [] as Array<{ id: string; title?: string }>),
+    mockGetSourcesAsync: vi.fn(async () => [{ id: 'src1', type: 'local', name: 'Local' }]),
+    mockCreateCalendarAsync: vi.fn(async () => 'cal-1'),
+    mockDeleteCalendarAsync: vi.fn(async () => {}),
+    mockCreateEventAsync: vi.fn(async () => 'evt-1'),
+    mockUpdateEventAsync: vi.fn(async () => 'evt-1'),
+    mockDeleteEventAsync: vi.fn(async () => {}),
+    mockGetCalendarSyncEntry: vi.fn(async () => null as null | {
+        taskId: string; calendarEventId: string; calendarId: string; platform: string; lastSyncedAt: string;
+    }),
+    mockUpsertCalendarSyncEntry: vi.fn(async () => {}),
+    mockDeleteCalendarSyncEntry: vi.fn(async () => {}),
+    mockGetAllCalendarSyncEntries: vi.fn(async () => [] as Array<{
+        taskId: string; calendarEventId: string; calendarId: string; platform: string; lastSyncedAt: string;
+    }>),
+    mockGetState: vi.fn(() => ({ tasks: [] as unknown[] })),
+    mockLogInfo: vi.fn(),
+    mockLogWarn: vi.fn(),
+    mockLogError: vi.fn(),
+}));
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+    default: {
+        getItem: mockGetItem,
+        setItem: mockSetItem,
+        removeItem: mockRemoveItem,
+    },
+}));
+
+vi.mock('expo-calendar', () => ({
+    EntityTypes: { EVENT: 'event' },
+    SourceType: { LOCAL: 'local', CALDAV: 'caldav' },
+    CalendarAccessLevel: { OWNER: 'owner' },
+    getCalendarsAsync: mockGetCalendarsAsync,
+    getSourcesAsync: mockGetSourcesAsync,
+    createCalendarAsync: mockCreateCalendarAsync,
+    deleteCalendarAsync: mockDeleteCalendarAsync,
+    createEventAsync: mockCreateEventAsync,
+    updateEventAsync: mockUpdateEventAsync,
+    deleteEventAsync: mockDeleteEventAsync,
+    getCalendarPermissionsAsync: vi.fn(async () => ({ status: 'granted' })),
+    requestCalendarPermissionsAsync: vi.fn(async () => ({ status: 'granted' })),
+}));
+
+vi.mock('react-native', () => ({
+    Platform: { OS: 'ios' },
+}));
+
+vi.mock('@mindwtr/core', () => ({
+    useTaskStore: {
+        getState: mockGetState,
+        subscribe: vi.fn(() => () => {}),
+    },
+}));
+
+vi.mock('@/lib/storage-adapter', () => ({
+    getCalendarSyncEntry: mockGetCalendarSyncEntry,
+    upsertCalendarSyncEntry: mockUpsertCalendarSyncEntry,
+    deleteCalendarSyncEntry: mockDeleteCalendarSyncEntry,
+    getAllCalendarSyncEntries: mockGetAllCalendarSyncEntries,
+}));
+
+vi.mock('@/lib/app-log', () => ({
+    logInfo: mockLogInfo,
+    logWarn: mockLogWarn,
+    logError: mockLogError,
+}));
+
+// ---------------------------------------------------------------------------
+// Subject under test — imported AFTER mocks are established
+// ---------------------------------------------------------------------------
+
+import {
+    ensureMindwtrCalendar,
+    runFullCalendarSync,
+} from '@/lib/calendar-push-sync';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides: Partial<{
+    id: string;
+    title: string;
+    status: string;
+    dueDate: string | null;
+    deletedAt: string | null;
+    updatedAt: string;
+}> = {}) {
+    return {
+        id: 'task-1',
+        title: 'My Task',
+        status: 'next',
+        dueDate: '2026-04-20',
+        deletedAt: null,
+        updatedAt: new Date().toISOString(),
+        description: '',
+        ...overrides,
+    };
+}
+
+/** Sets up the two AsyncStorage.getItem calls made by runFullCalendarSync. */
+function setupEnabled(calendarId = 'cal-1') {
+    mockGetItem
+        .mockResolvedValueOnce('1')         // getCalendarPushEnabled → enabled
+        .mockResolvedValueOnce(calendarId); // ensureMindwtrCalendar → stored ID
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: the stored calendar still exists
+    mockGetCalendarsAsync.mockResolvedValue([{ id: 'cal-1', title: 'Mindwtr' }]);
+    // Default: no prior sync entries
+    mockGetCalendarSyncEntry.mockResolvedValue(null);
+    mockGetAllCalendarSyncEntries.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ensureMindwtrCalendar', () => {
+    it('returns the stored calendar ID when the calendar still exists', async () => {
+        mockGetItem.mockResolvedValueOnce('cal-1'); // CALENDAR_ID_KEY
+
+        const id = await ensureMindwtrCalendar();
+
+        expect(id).toBe('cal-1');
+        expect(mockCreateCalendarAsync).not.toHaveBeenCalled();
+    });
+
+    it('recreates the calendar when the stored one has been deleted', async () => {
+        mockGetItem.mockResolvedValueOnce('cal-old'); // stored but gone
+        mockGetCalendarsAsync.mockResolvedValue([]);  // not found
+        mockCreateCalendarAsync.mockResolvedValue('cal-2');
+
+        const id = await ensureMindwtrCalendar();
+
+        expect(mockCreateCalendarAsync).toHaveBeenCalledOnce();
+        expect(id).toBe('cal-2');
+        expect(mockSetItem).toHaveBeenCalledWith('mindwtr:calendar-push-sync:calendar-id', 'cal-2');
+    });
+});
+
+describe('runFullCalendarSync — completion removes event', () => {
+    it('removes a calendar event when the task is marked done', async () => {
+        setupEnabled();
+        const task = makeTask({ status: 'done' });
+        mockGetState.mockReturnValue({ tasks: [task] });
+        const entry = { taskId: task.id, calendarEventId: 'evt-done', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' };
+        mockGetCalendarSyncEntry.mockResolvedValue(entry);
+        mockGetAllCalendarSyncEntries.mockResolvedValue([]);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).toHaveBeenCalledWith('evt-done');
+        expect(mockDeleteCalendarSyncEntry).toHaveBeenCalledWith(task.id, 'ios');
+        expect(mockCreateEventAsync).not.toHaveBeenCalled();
+    });
+
+    it('removes a calendar event when the task is archived', async () => {
+        setupEnabled();
+        const task = makeTask({ status: 'archived' });
+        mockGetState.mockReturnValue({ tasks: [task] });
+        mockGetCalendarSyncEntry.mockResolvedValue(
+            { taskId: task.id, calendarEventId: 'evt-arch', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' }
+        );
+        mockGetAllCalendarSyncEntries.mockResolvedValue([]);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).toHaveBeenCalledWith('evt-arch');
+        expect(mockCreateEventAsync).not.toHaveBeenCalled();
+    });
+});
+
+describe('runFullCalendarSync — event removal', () => {
+    it('removes a calendar event when dueDate is cleared', async () => {
+        setupEnabled();
+        const task = makeTask({ dueDate: null });
+        mockGetState.mockReturnValue({ tasks: [task] });
+        mockGetCalendarSyncEntry.mockResolvedValue(
+            { taskId: task.id, calendarEventId: 'evt-old', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' }
+        );
+        mockGetAllCalendarSyncEntries.mockResolvedValue([]);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).toHaveBeenCalledWith('evt-old');
+        expect(mockCreateEventAsync).not.toHaveBeenCalled();
+    });
+
+    it('removes a calendar event when the task is soft-deleted', async () => {
+        setupEnabled();
+        const task = makeTask({ deletedAt: new Date().toISOString() });
+        mockGetState.mockReturnValue({ tasks: [task] });
+        mockGetCalendarSyncEntry.mockResolvedValue(
+            { taskId: task.id, calendarEventId: 'evt-del', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' }
+        );
+        mockGetAllCalendarSyncEntries.mockResolvedValue([]);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).toHaveBeenCalledWith('evt-del');
+    });
+});
+
+describe('runFullCalendarSync — startup reconciliation', () => {
+    it('removes stale events for tasks no longer in the store', async () => {
+        setupEnabled();
+        mockGetState.mockReturnValue({ tasks: [] });
+        const ghostEntry = { taskId: 'ghost-task', calendarEventId: 'evt-ghost', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' };
+        mockGetAllCalendarSyncEntries.mockResolvedValue([ghostEntry]);
+        mockGetCalendarSyncEntry.mockResolvedValue(ghostEntry);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).toHaveBeenCalledWith('evt-ghost');
+        expect(mockDeleteCalendarSyncEntry).toHaveBeenCalledWith('ghost-task', 'ios');
+    });
+
+    it('removes stale events for tasks completed between sessions', async () => {
+        setupEnabled();
+        const task = makeTask({ status: 'done' });
+        mockGetState.mockReturnValue({ tasks: [task] });
+        const staleEntry = { taskId: task.id, calendarEventId: 'evt-stale', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' };
+        mockGetAllCalendarSyncEntries.mockResolvedValue([staleEntry]);
+        mockGetCalendarSyncEntry.mockResolvedValue(staleEntry);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).toHaveBeenCalledWith('evt-stale');
+    });
+
+    it('does not touch events for active tasks with due dates', async () => {
+        setupEnabled();
+        const task = makeTask();
+        mockGetState.mockReturnValue({ tasks: [task] });
+        const activeEntry = { taskId: task.id, calendarEventId: 'evt-active', calendarId: 'cal-1', platform: 'ios', lastSyncedAt: '' };
+        mockGetCalendarSyncEntry.mockResolvedValue(activeEntry);
+        mockGetAllCalendarSyncEntries.mockResolvedValue([activeEntry]);
+
+        await runFullCalendarSync();
+
+        expect(mockDeleteEventAsync).not.toHaveBeenCalled();
+        expect(mockUpdateEventAsync).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/mobile/tests/use-root-layout-notification-open-handler.test.tsx
+++ b/apps/mobile/tests/use-root-layout-notification-open-handler.test.tsx
@@ -11,7 +11,7 @@ const {
 } = vi.hoisted(() => ({
   setNotificationOpenHandler: vi.fn(),
   setHighlightTask: vi.fn(),
-  consumePendingNotificationOpenPayload: vi.fn(async () => null),
+  consumePendingNotificationOpenPayload: vi.fn(async (): Promise<{ kind?: string; notificationId?: string; taskId?: string; projectId?: string; actionIdentifier?: string } | null> => null),
 }));
 
 vi.mock('@mindwtr/core', () => ({

--- a/apps/mobile/types/native-modules.d.ts
+++ b/apps/mobile/types/native-modules.d.ts
@@ -111,6 +111,16 @@ declare module 'expo-calendar' {
     title?: string;
     name?: string;
     color?: string;
+    sourceId?: string;
+    source?: Source;
+    entityType?: string;
+    allowsModifications?: boolean;
+  }
+
+  export interface Source {
+    id: string;
+    type: string;
+    name: string;
   }
 
   export interface Event {
@@ -126,12 +136,43 @@ declare module 'expo-calendar' {
 
   export const EntityTypes: {
     EVENT: string;
+    REMINDER: string;
   };
+
+  export enum SourceType {
+    LOCAL = 'local',
+    EXCHANGE = 'exchange',
+    CALDAV = 'caldav',
+    MOBILEME = 'mobileme',
+    SUBSCRIBED = 'subscribed',
+    BIRTHDAYS = 'birthdays',
+  }
+
+  export enum CalendarAccessLevel {
+    CONTRIBUTOR = 'contributor',
+    EDITOR = 'editor',
+    FREEBUSY = 'freebusy',
+    NONE = 'none',
+    OWNER = 'owner',
+    READ = 'read',
+    RESPOND = 'respond',
+    ROOT = 'root',
+    OVERRIDE = 'override',
+    UNKNOWN = 'unknown',
+  }
 
   export function getCalendarPermissionsAsync(): Promise<{ status: PermissionStatus }>;
   export function requestCalendarPermissionsAsync(): Promise<{ status: PermissionStatus }>;
-  export function getCalendarsAsync(entityType: string): Promise<Calendar[]>;
+  export function getCalendarsAsync(entityType?: string): Promise<Calendar[]>;
   export function getEventsAsync(calendarIds: string[], startDate: Date, endDate: Date): Promise<Event[]>;
+  export function getSourcesAsync(): Promise<Source[]>;
+
+  // Write APIs
+  export function createCalendarAsync(details?: Partial<Calendar>): Promise<string>;
+  export function deleteCalendarAsync(id: string): Promise<void>;
+  export function createEventAsync(calendarId: string, eventData?: Partial<Omit<Event, 'id'>>): Promise<string>;
+  export function updateEventAsync(id: string, details?: Partial<Omit<Event, 'id'>>): Promise<string>;
+  export function deleteEventAsync(id: string): Promise<void>;
 }
 
 declare module 'expo-network' {

--- a/apps/mobile/types/native-modules.d.ts
+++ b/apps/mobile/types/native-modules.d.ts
@@ -115,6 +115,8 @@ declare module 'expo-calendar' {
     source?: Source;
     entityType?: string;
     allowsModifications?: boolean;
+    ownerAccount?: string;
+    accessLevel?: CalendarAccessLevel;
   }
 
   export interface Source {

--- a/packages/core/src/sqlite-adapter.ts
+++ b/packages/core/src/sqlite-adapter.ts
@@ -1,4 +1,12 @@
 import type { AppData, Area, Attachment, Project, Task, Section } from './types';
+
+export type CalendarSyncEntry = {
+    taskId: string;
+    calendarEventId: string;
+    calendarId: string;
+    platform: string;
+    lastSyncedAt: string;
+};
 import type { SearchProjectResult, SearchResults, SearchTaskResult, TaskQueryOptions } from './storage';
 import { SQLITE_BASE_SCHEMA, SQLITE_FTS_SCHEMA, SQLITE_INDEX_SCHEMA } from './sqlite-schema';
 import { normalizeTaskStatus } from './task-status';
@@ -1110,5 +1118,65 @@ export class SqliteAdapter {
             await this.client.run('ROLLBACK');
             throw error;
         }
+    }
+
+    // MARK: - Calendar Sync CRUD
+
+    async getCalendarSyncEntry(taskId: string, platform: string): Promise<CalendarSyncEntry | null> {
+        await this.ensureSchema();
+        const row = await this.client.get<{
+            task_id: string;
+            calendar_event_id: string;
+            calendar_id: string;
+            platform: string;
+            last_synced_at: string;
+        }>('SELECT * FROM calendar_sync WHERE task_id = ? AND platform = ?', [taskId, platform]);
+        if (!row) return null;
+        return {
+            taskId: row.task_id,
+            calendarEventId: row.calendar_event_id,
+            calendarId: row.calendar_id,
+            platform: row.platform,
+            lastSyncedAt: row.last_synced_at,
+        };
+    }
+
+    async upsertCalendarSyncEntry(entry: CalendarSyncEntry): Promise<void> {
+        await this.ensureSchema();
+        await this.client.run(
+            `INSERT INTO calendar_sync (task_id, calendar_event_id, calendar_id, platform, last_synced_at)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(task_id, platform) DO UPDATE SET
+               calendar_event_id = excluded.calendar_event_id,
+               calendar_id = excluded.calendar_id,
+               last_synced_at = excluded.last_synced_at`,
+            [entry.taskId, entry.calendarEventId, entry.calendarId, entry.platform, entry.lastSyncedAt]
+        );
+    }
+
+    async deleteCalendarSyncEntry(taskId: string, platform: string): Promise<void> {
+        await this.ensureSchema();
+        await this.client.run(
+            'DELETE FROM calendar_sync WHERE task_id = ? AND platform = ?',
+            [taskId, platform]
+        );
+    }
+
+    async getAllCalendarSyncEntries(platform: string): Promise<CalendarSyncEntry[]> {
+        await this.ensureSchema();
+        const rows = await this.client.all<{
+            task_id: string;
+            calendar_event_id: string;
+            calendar_id: string;
+            platform: string;
+            last_synced_at: string;
+        }>('SELECT * FROM calendar_sync WHERE platform = ?', [platform]);
+        return rows.map((row) => ({
+            taskId: row.task_id,
+            calendarEventId: row.calendar_event_id,
+            calendarId: row.calendar_id,
+            platform: row.platform,
+            lastSyncedAt: row.last_synced_at,
+        }));
     }
 }

--- a/packages/core/src/sqlite-schema.ts
+++ b/packages/core/src/sqlite-schema.ts
@@ -1,4 +1,4 @@
-export const SQLITE_SCHEMA_VERSION = 2;
+export const SQLITE_SCHEMA_VERSION = 3;
 
 export const SQLITE_BASE_SCHEMA = `
 PRAGMA journal_mode = WAL;
@@ -95,6 +95,15 @@ CREATE TABLE IF NOT EXISTS settings (
 
 CREATE TABLE IF NOT EXISTS schema_migrations (
   version INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS calendar_sync (
+  task_id TEXT NOT NULL,
+  calendar_event_id TEXT NOT NULL,
+  calendar_id TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  last_synced_at TEXT NOT NULL,
+  PRIMARY KEY (task_id, platform)
 );
 
 INSERT OR IGNORE INTO schema_migrations (version) VALUES (1);


### PR DESCRIPTION
## Summary

- Tasks with due dates are automatically synced to a dedicated "Mindwtr"
  calendar on the device using Expo Calendar write APIs (create/update/delete)
- Event-to-task mapping stored in a new `calendar_sync` SQLite table
  (schema version 3) so mappings survive app restarts
- Store subscription with 2.5s debounce keeps the calendar up to date as
  tasks change; full sync runs on app startup

## Settings

A new toggle in **Settings → Calendar** lets users:
- Enable/disable the push sync (requests write permission on first enable)
- Delete the managed "Mindwtr" calendar and all its events

## Notes

- One-way push only — changes made directly in the OS calendar are not
  reflected back in Mindwtr (consistent with GTD inbox discipline)
- No RRULE support in v1; recurring tasks write a single event per due date
- Mobile only; desktop unaffected (calendar_sync table is created but unused)

## Test plan

- [ ] Enable toggle → permission prompt appears, "Mindwtr" calendar created
- [ ] Add a due date to a task → event appears in device Calendar app within ~3s
- [ ] Edit the task title or due date → event updates
- [ ] Remove the due date → event is deleted
- [ ] Complete/delete the task → event is deleted
- [ ] Delete the Mindwtr calendar externally → re-enable recreates it
- [ ] "Delete Mindwtr calendar…" removes the calendar and all events
- [ ] Disable toggle → sync stops; existing events are kept