### PR TITLE
fix reference translation in `zh-Hans.ts`

### DIFF
--- a/packages/core/src/i18n/locales/zh-Hans.ts
+++ b/packages/core/src/i18n/locales/zh-Hans.ts
@@ -105,7 +105,7 @@ export const zhHans: Record<string, string> = {
         'list.groupByContext': '情境',
         'list.groupByArea': '领域',
         'reference.empty': '暂无参考资料。',
-        'reference.emptyHint': '参考资料包含你日后可能需要的信息 —— 无需采取任何行动。'
+        'reference.emptyHint': '参考资料包含你日后可能需要的信息 —— 无需采取任何行动。',
         'status.inbox': '收集箱',
         'status.todo': '待办',
         'status.next': '下一步',

--- a/packages/core/src/i18n/locales/zh-Hans.ts
+++ b/packages/core/src/i18n/locales/zh-Hans.ts
@@ -104,7 +104,8 @@ export const zhHans: Record<string, string> = {
         'list.groupByNone': '不分组',
         'list.groupByContext': '情境',
         'list.groupByArea': '领域',
-        'reference.empty': '暂无参考条目。',
+        'reference.empty': '暂无参考资料。',
+        'reference.emptyHint': '参考资料包含你日后可能需要的信息 —— 无需采取任何行动。'
         'status.inbox': '收集箱',
         'status.todo': '待办',
         'status.next': '下一步',
@@ -919,7 +920,7 @@ export const zhHans: Record<string, string> = {
         'search.deleteConfirm': '删除此已保存的搜索？',
         'search.helpOperators': '可用操作符：status:、context:、tag:、project:、due:<=7d 等。',
         'search.includeCompleted': '包含已完成和归档任务',
-        'search.includeReference': '包含参考任务',
+        'search.includeReference': '包含参考资料',
         'search.include.label': '包含',
         'search.scope.label': '范围',
         'search.scope.all': '全部',


### PR DESCRIPTION
## Summary

Translate the Chinese term "参考资料" to "References" for consistency, and translate `reference.emptyHint`.

## Related issue

<!-- Link to GitHub issue if applicable, e.g. "Fixes #123" -->

## Testing

<!-- Commands run, platforms/devices checked, and outcomes -->

## Screenshots / recordings

<!-- Required for UI changes. Otherwise write "N/A". -->

## Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](https://gist.github.com/dongdongbh/0446c35e1d5c1a73c344b16cba4aeeaa)
- [ ] I have tested this change locally
- [ ] I linked the relevant issue (or explained why there isn't one)
- [ ] I added or updated tests/docs if needed
