### PR TITLE
feat(android): add quick settings capture tile

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -135,6 +135,7 @@
       ],
       "expo-secure-store",
       "./plugins/android-app-shortcuts",
+      "./plugins/android-quick-settings-tile",
       "./plugins/android-manifest-fixes",
       "./plugins/android-startup-trace",
       "./plugins/patch-alarm-notification-gradle"

--- a/apps/mobile/plugins/android-quick-settings-tile.js
+++ b/apps/mobile/plugins/android-quick-settings-tile.js
@@ -1,0 +1,189 @@
+const fs = require('fs');
+const path = require('path');
+const { withAndroidManifest, withDangerousMod } = require('@expo/config-plugins');
+
+const CAPTURE_URI = 'mindwtr:///capture-quick?mode=text';
+const SERVICE_NAME = '.quicksettings.CaptureTileService';
+const SERVICE_PERMISSION = 'android.permission.BIND_QUICK_SETTINGS_TILE';
+const QS_TILE_ACTION = 'android.service.quicksettings.action.QS_TILE';
+const TILE_LABEL = '@string/quick_settings_capture_tile_label';
+const TILE_ICON = '@drawable/ic_quick_settings_capture';
+const STRINGS_FILE_NAME = 'mindwtr_quick_settings_tile_strings.xml';
+const ICON_FILE_NAME = 'ic_quick_settings_capture.xml';
+
+const buildTileStringsXml = () => `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="quick_settings_capture_tile_label" translatable="false">Capture</string>
+  <string name="quick_settings_capture_tile_description" translatable="false">Open Mindwtr quick capture</string>
+</resources>
+`;
+
+const buildTileIconXml = () => `<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M12,3C7.03,3 3,7.03 3,12s4.03,9 9,9 9,-4.03 9,-9 -4.03,-9 -9,-9zM12,5c3.86,0 7,3.14 7,7s-3.14,7 -7,7 -7,-3.14 -7,-7 3.14,-7 7,-7zM11,8h2v3h3v2h-3v3h-2v-3H8v-2h3z" />
+</vector>
+`;
+
+const buildCaptureTileServiceSource = (packageName) => `package ${packageName}.quicksettings
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import ${packageName}.R
+
+class CaptureTileService : TileService() {
+  override fun onTileAdded() {
+    super.onTileAdded()
+    updateTileState()
+  }
+
+  override fun onStartListening() {
+    super.onStartListening()
+    updateTileState()
+  }
+
+  override fun onClick() {
+    super.onClick()
+
+    if (isLocked) {
+      unlockAndRun { launchQuickCapture() }
+      return
+    }
+
+    launchQuickCapture()
+  }
+
+  private fun updateTileState() {
+    qsTile?.apply {
+      label = getString(R.string.quick_settings_capture_tile_label)
+      contentDescription = getString(R.string.quick_settings_capture_tile_description)
+      state = Tile.STATE_ACTIVE
+      updateTile()
+    }
+  }
+
+  @Suppress("DEPRECATION")
+  private fun launchQuickCapture() {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(CAPTURE_URI)).apply {
+      setClassName(packageName, "$packageName.MainActivity")
+      addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      val pendingIntent = PendingIntent.getActivity(
+        this,
+        CAPTURE_REQUEST_CODE,
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+      )
+      startActivityAndCollapse(pendingIntent)
+    } else {
+      startActivityAndCollapse(intent)
+    }
+  }
+
+  companion object {
+    private const val CAPTURE_URI = "${CAPTURE_URI}"
+    private const val CAPTURE_REQUEST_CODE = 461
+  }
+}
+`;
+
+const findCaptureTileService = (services) =>
+  services.find((service) => service?.$?.['android:name'] === SERVICE_NAME);
+
+const ensureQsTileIntentFilter = (service) => {
+  if (!Array.isArray(service['intent-filter'])) {
+    service['intent-filter'] = [];
+  }
+
+  const existingFilter = service['intent-filter'].find((filter) => {
+    const actions = Array.isArray(filter?.action) ? filter.action : [];
+    return actions.some((action) => action?.$?.['android:name'] === QS_TILE_ACTION);
+  });
+
+  if (existingFilter) return;
+
+  service['intent-filter'].push({
+    action: [{ $: { 'android:name': QS_TILE_ACTION } }],
+  });
+};
+
+const ensureCaptureTileService = (androidManifest) => {
+  const application = androidManifest?.manifest?.application?.[0];
+  if (!application) return androidManifest;
+
+  if (!Array.isArray(application.service)) {
+    application.service = [];
+  }
+
+  const service = findCaptureTileService(application.service) ?? {
+    $: { 'android:name': SERVICE_NAME },
+  };
+
+  service.$ = {
+    ...service.$,
+    'android:name': SERVICE_NAME,
+    'android:label': TILE_LABEL,
+    'android:icon': TILE_ICON,
+    'android:permission': SERVICE_PERMISSION,
+    'android:exported': 'true',
+  };
+  ensureQsTileIntentFilter(service);
+
+  if (!application.service.includes(service)) {
+    application.service.push(service);
+  }
+
+  return androidManifest;
+};
+
+module.exports = function withAndroidQuickSettingsTile(config) {
+  const withManifest = withAndroidManifest(config, (cfg) => {
+    ensureCaptureTileService(cfg.modResults);
+    return cfg;
+  });
+
+  return withDangerousMod(withManifest, [
+    'android',
+    async (cfg) => {
+      const packageName = cfg.android?.package || cfg.modRequest.projectName;
+      if (!packageName) return cfg;
+
+      const mainRoot = path.join(cfg.modRequest.platformProjectRoot, 'app', 'src', 'main');
+      const packageDir = packageName.replace(/\./g, path.sep);
+      const serviceDir = path.join(mainRoot, 'java', packageDir, 'quicksettings');
+      const valuesDir = path.join(mainRoot, 'res', 'values');
+      const drawableDir = path.join(mainRoot, 'res', 'drawable');
+
+      await fs.promises.mkdir(serviceDir, { recursive: true });
+      await fs.promises.mkdir(valuesDir, { recursive: true });
+      await fs.promises.mkdir(drawableDir, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(serviceDir, 'CaptureTileService.kt'),
+        buildCaptureTileServiceSource(packageName),
+        'utf8'
+      );
+      await fs.promises.writeFile(path.join(valuesDir, STRINGS_FILE_NAME), buildTileStringsXml(), 'utf8');
+      await fs.promises.writeFile(path.join(drawableDir, ICON_FILE_NAME), buildTileIconXml(), 'utf8');
+
+      return cfg;
+    },
+  ]);
+};
+
+module.exports.__testables = {
+  buildCaptureTileServiceSource,
+  buildTileIconXml,
+  buildTileStringsXml,
+  ensureCaptureTileService,
+};

--- a/apps/mobile/plugins/android-quick-settings-tile.test.js
+++ b/apps/mobile/plugins/android-quick-settings-tile.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+const plugin = require('./android-quick-settings-tile');
+
+const {
+  buildCaptureTileServiceSource,
+  buildTileIconXml,
+  buildTileStringsXml,
+  ensureCaptureTileService,
+} = plugin.__testables;
+
+describe('android-quick-settings-tile', () => {
+  it('generates a TileService that opens the existing quick capture route', () => {
+    const source = buildCaptureTileServiceSource('tech.dongdongbh.mindwtr');
+
+    expect(source).toContain('class CaptureTileService : TileService()');
+    expect(source).toContain('mindwtr:///capture-quick?mode=text');
+    expect(source).toContain('unlockAndRun { launchQuickCapture() }');
+    expect(source).toContain('Build.VERSION_CODES.UPSIDE_DOWN_CAKE');
+    expect(source).toContain('PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE');
+    expect(source).toContain('startActivityAndCollapse(pendingIntent)');
+    expect(source).toContain('startActivityAndCollapse(intent)');
+    expect(source).toContain('setClassName(packageName, "$packageName.MainActivity")');
+  });
+
+  it('adds the protected quick settings service to the Android manifest idempotently', () => {
+    const manifest = {
+      manifest: {
+        application: [
+          {
+            service: [],
+          },
+        ],
+      },
+    };
+
+    ensureCaptureTileService(manifest);
+    const once = JSON.stringify(manifest);
+    ensureCaptureTileService(manifest);
+
+    expect(JSON.stringify(manifest)).toBe(once);
+    expect(manifest.manifest.application[0].service).toHaveLength(1);
+    expect(manifest.manifest.application[0].service[0]).toEqual({
+      $: {
+        'android:name': '.quicksettings.CaptureTileService',
+        'android:label': '@string/quick_settings_capture_tile_label',
+        'android:icon': '@drawable/ic_quick_settings_capture',
+        'android:permission': 'android.permission.BIND_QUICK_SETTINGS_TILE',
+        'android:exported': 'true',
+      },
+      'intent-filter': [
+        {
+          action: [
+            {
+              $: {
+                'android:name': 'android.service.quicksettings.action.QS_TILE',
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('generates the tile string and icon resources', () => {
+    expect(buildTileStringsXml()).toContain('name="quick_settings_capture_tile_label"');
+    expect(buildTileStringsXml()).toContain('Capture');
+    expect(buildTileIconXml()).toContain('<vector');
+    expect(buildTileIconXml()).toContain('android:fillColor="#FFFFFFFF"');
+  });
+});


### PR DESCRIPTION
## Summary
- add an Android Quick Settings Tile Expo config plugin for quick capture
- generate the protected `TileService`, manifest entry, icon, and strings during Android prebuild
- route tile taps to the existing `mindwtr:///capture-quick?mode=text` flow, including Android 14+ `PendingIntent` handling

## Tests
- `bunx vitest run plugins/android-quick-settings-tile.test.js`
- `./gradlew :app:compileDebugKotlin`

Closes #461
