### PR TITLE
fix(mcp-server): FTS search never matched (contentless table id is NULL)

### DIFF
--- a/apps/mcp-server/src/queries.test.ts
+++ b/apps/mcp-server/src/queries.test.ts
@@ -122,6 +122,10 @@ describe('mcp queries', () => {
         const queryCall = calls.find((call) => call.sql.startsWith('SELECT') && call.sql.includes('FROM tasks '));
         expect(queryCall).toBeTruthy();
         expect(queryCall?.sql.includes('tasks_fts MATCH ?')).toBe(true);
+        // tasks_fts is a contentless FTS5 table (content=''), so its id column is
+        // always NULL; the lookup must join on rowid or it matches nothing.
+        expect(queryCall?.sql.includes('rowid IN (SELECT rowid FROM tasks_fts')).toBe(true);
+        expect(queryCall?.sql.includes('id IN (SELECT id FROM tasks_fts')).toBe(false);
         expect(queryCall?.params[0]).toBe('project* alpha*');
     });
 

--- a/apps/mcp-server/src/queries.ts
+++ b/apps/mcp-server/src/queries.ts
@@ -203,7 +203,7 @@ export function listTasks(db: DbClient, input: ListTasksInput): TaskRow[] {
   if (input.search) {
     const ftsQuery = buildTasksFtsQuery(input.search);
     if (ftsQuery && hasTasksFts(db)) {
-      where.push("id IN (SELECT id FROM tasks_fts WHERE tasks_fts MATCH ?)");
+      where.push("rowid IN (SELECT rowid FROM tasks_fts WHERE tasks_fts MATCH ?)");
       params.push(ftsQuery);
     } else {
       where.push("(title LIKE ? ESCAPE '\\' OR description LIKE ? ESCAPE '\\')");


### PR DESCRIPTION
## Problem

`mindwtr_list_tasks` with a `search` argument returns **zero results** whenever the `tasks_fts` table exists, because the lookup in `apps/mcp-server/src/queries.ts` does:

```sql
id IN (SELECT id FROM tasks_fts WHERE tasks_fts MATCH ?)
```

`tasks_fts` is a contentless FTS5 table (`content=''`) and the triggers populate it via `rowid` only — the `id UNINDEXED` column is always NULL, so the subquery never matches anything. The LIKE fallback masks the bug on databases without FTS, which is probably why it went unnoticed.

## Fix

Join on `rowid` instead, which contentless tables do store:

```sql
rowid IN (SELECT rowid FROM tasks_fts WHERE tasks_fts MATCH ?)
```

This matches what the `tasks_ai`/`tasks_ad`/`tasks_au` triggers write.

## Testing

- Extended the existing `listTasks uses FTS search` unit test to assert the subquery joins on `rowid` (and not the always-NULL `id`), so this can't regress silently.
- `bun test apps/mcp-server/src/queries.test.ts` → 17/17 pass.
- Verified against a live database: search returned 0 rows before, correct rows after.

Found while exercising the MCP server end-to-end; unrelated to my pending #684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)