### PR TITLE
feat(ai): add OrcaRouter as a first-class AI provider

### DIFF
--- a/apps/desktop/src/components/views/settings/SettingsAiPage.test.tsx
+++ b/apps/desktop/src/components/views/settings/SettingsAiPage.test.tsx
@@ -15,6 +15,7 @@ const t = {
     aiProviderOpenAI: 'OpenAI',
     aiProviderGemini: 'Gemini',
     aiProviderAnthropic: 'Anthropic (Claude)',
+    aiProviderOrcaRouter: 'OrcaRouter',
     aiModel: 'Model',
     aiBaseUrl: 'Custom OpenAI-compatible base URL',
     aiBaseUrlHint: 'Leave blank for official OpenAI. Set this for local or third-party OpenAI-compatible APIs such as llama.cpp, Ollama, LM Studio, GLM, or vLLM.',

--- a/apps/desktop/src/components/views/settings/SettingsAiPage.tsx
+++ b/apps/desktop/src/components/views/settings/SettingsAiPage.tsx
@@ -20,6 +20,7 @@ type Labels = {
     aiProviderOpenAI: string;
     aiProviderGemini: string;
     aiProviderAnthropic: string;
+    aiProviderOrcaRouter: string;
     aiModel: string;
     aiBaseUrl: string;
     aiBaseUrlHint: string;
@@ -325,6 +326,7 @@ export function SettingsAiPage({
                                     <option value="openai">{t.aiProviderOpenAI}</option>
                                     <option value="gemini">{t.aiProviderGemini}</option>
                                     <option value="anthropic">{t.aiProviderAnthropic}</option>
+                                    <option value="orcarouter">{t.aiProviderOrcaRouter}</option>
                                 </select>
                             </SettingRow>
 

--- a/apps/desktop/src/components/views/settings/labels.ts
+++ b/apps/desktop/src/components/views/settings/labels.ts
@@ -211,6 +211,7 @@ export const SETTINGS_LABEL_KEYS = [
     'aiProviderOpenAI',
     'aiProviderGemini',
     'aiProviderAnthropic',
+    'aiProviderOrcaRouter',
     'aiModel',
     'aiBaseUrl',
     'aiBaseUrlHint',

--- a/apps/mobile/components/settings/ai-settings-assistant-card.tsx
+++ b/apps/mobile/components/settings/ai-settings-assistant-card.tsx
@@ -9,6 +9,7 @@ import { CompactText } from '@/components/compact-text';
 import { AiSettingsAssistantAnthropicPanel } from './ai-settings-assistant-anthropic-panel';
 import { AiSettingsAssistantGeminiPanel } from './ai-settings-assistant-gemini-panel';
 import { AiSettingsAssistantOpenAiPanel } from './ai-settings-assistant-openai-panel';
+import { AiSettingsAssistantOrcaRouterPanel } from './ai-settings-assistant-orcarouter-panel';
 import { styles } from './settings.styles';
 
 type SettingsTranslator = (key: string, values?: Record<string, string | number | boolean | null | undefined>) => string;
@@ -164,6 +165,22 @@ export function AiSettingsAssistantCard({
                                     </CompactText>
                                 </TouchableOpacity>
                             )}
+                            {!isFossBuild && (
+                                <TouchableOpacity
+                                    style={[
+                                        styles.backendOption,
+                                        { borderColor: tc.border, backgroundColor: aiProvider === 'orcarouter' ? tc.filterBg : 'transparent' },
+                                    ]}
+                                    onPress={() => onAiProviderChange('orcarouter')}
+                                >
+                                    <CompactText
+                                        style={[styles.backendOptionText, { color: aiProvider === 'orcarouter' ? tc.tint : tc.secondaryText }]}
+                                        numberOfLines={2}
+                                    >
+                                        {t('settings.aiProviderOrcaRouter')}
+                                    </CompactText>
+                                </TouchableOpacity>
+                            )}
                         </View>
                     </View>
 
@@ -254,7 +271,7 @@ export function AiSettingsAssistantCard({
                             t={t}
                             tc={tc}
                         />
-                    ) : (
+                    ) : aiProvider === 'anthropic' ? (
                         <AiSettingsAssistantAnthropicPanel
                             aiApiKey={aiApiKey}
                             aiThinkingBudget={aiThinkingBudget}
@@ -262,6 +279,13 @@ export function AiSettingsAssistantCard({
                             onAiApiKeyChange={onAiApiKeyChange}
                             onAiThinkingBudgetChange={onAiThinkingBudgetChange}
                             onAnthropicThinkingEnabledChange={onAnthropicThinkingEnabledChange}
+                            t={t}
+                            tc={tc}
+                        />
+                    ) : (
+                        <AiSettingsAssistantOrcaRouterPanel
+                            aiApiKey={aiApiKey}
+                            onAiApiKeyChange={onAiApiKeyChange}
                             t={t}
                             tc={tc}
                         />

--- a/apps/mobile/components/settings/ai-settings-assistant-orcarouter-panel.tsx
+++ b/apps/mobile/components/settings/ai-settings-assistant-orcarouter-panel.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Text, TextInput, View } from 'react-native';
+
+import type { ThemeColors } from '@/hooks/use-theme-colors';
+
+import { styles } from './settings.styles';
+
+type Translate = (key: string) => string;
+
+type AiSettingsAssistantOrcaRouterPanelProps = {
+    aiApiKey: string;
+    onAiApiKeyChange: (value: string) => void;
+    t: Translate;
+    tc: ThemeColors;
+};
+
+// OrcaRouter is a named OpenAI-compatible gateway provider, so unlike the OpenAI
+// panel there is no base-URL or extra-body-params to configure — only the key.
+export function AiSettingsAssistantOrcaRouterPanel({
+    aiApiKey,
+    onAiApiKeyChange,
+    t,
+    tc,
+}: AiSettingsAssistantOrcaRouterPanelProps) {
+    return (
+        <>
+            <View style={[styles.settingRow, { borderTopWidth: 1, borderTopColor: tc.border }]}>
+                <View style={styles.settingInfo}>
+                    <Text style={[styles.settingLabel, { color: tc.text }]}>{t('settings.aiApiKey')}</Text>
+                    <Text style={[styles.settingDescription, { color: tc.secondaryText }]}>{t('settings.aiApiKeyHint')}</Text>
+                </View>
+            </View>
+            <View style={{ paddingHorizontal: 16, paddingBottom: 16 }}>
+                <TextInput
+                    value={aiApiKey}
+                    onChangeText={onAiApiKeyChange}
+                    placeholder={t('settings.aiApiKeyPlaceholder')}
+                    placeholderTextColor={tc.secondaryText}
+                    autoCapitalize="none"
+                    secureTextEntry
+                    style={[styles.textInput, { borderColor: tc.border, color: tc.text }]}
+                />
+            </View>
+        </>
+    );
+}

--- a/apps/mobile/components/settings/ai-settings-screen.tsx
+++ b/apps/mobile/components/settings/ai-settings-screen.tsx
@@ -140,7 +140,9 @@ export function AISettingsScreen() {
                 ? t('settings.aiProviderOpenAI')
                 : provider === 'gemini'
                     ? t('settings.aiProviderGemini')
-                    : t('settings.aiProviderAnthropic')
+                    : provider === 'anthropic'
+                        ? t('settings.aiProviderAnthropic')
+                        : t('settings.aiProviderOrcaRouter')
     );
 
     const getAIProviderPolicyUrl = (provider: AIProviderId): string => (
@@ -150,7 +152,9 @@ export function AISettingsScreen() {
                 ? 'https://openai.com/policies/privacy-policy'
                 : provider === 'gemini'
                     ? 'https://policies.google.com/privacy'
-                    : 'https://www.anthropic.com/privacy'
+                    : provider === 'anthropic'
+                        ? 'https://www.anthropic.com/privacy'
+                        : 'https://www.orcarouter.ai/privacy-policy'
     );
 
     const loadAIProviderConsent = async (): Promise<Record<string, boolean>> => {

--- a/apps/mobile/components/settings/settings.constants.ts
+++ b/apps/mobile/components/settings/settings.constants.ts
@@ -140,6 +140,7 @@ const MOBILE_ROW_EXTRA_KEYS: Record<SettingsMenuRowId, readonly string[]> = {
     advanced: [
         'settings.aiProvider', 'settings.aiModel', 'settings.aiApiKey',
         'settings.aiProviderOpenAI', 'settings.aiProviderAnthropic', 'settings.aiProviderGemini',
+        'settings.aiProviderOrcaRouter',
         // Desktop indexes these on its Integrations page, which has no mobile
         // row; mobile renders them on the Calendar screen under Advanced.
         'settings.calendar', 'settings.calendarMobile.icsSubscriptions', 'settings.externalCalendars',

--- a/apps/mobile/components/settings/settings.search.test.ts
+++ b/apps/mobile/components/settings/settings.search.test.ts
@@ -74,6 +74,7 @@ const PREVIOUS_SETTINGS_MENU_KEYWORD_KEYS: Record<SettingsMenuRowId, readonly st
     advanced: [
         'settings.advanced', 'settings.ai', 'settings.aiProvider', 'settings.aiModel', 'settings.aiApiKey',
         'settings.aiProviderOpenAI', 'settings.aiProviderAnthropic', 'settings.aiProviderGemini',
+        'settings.aiProviderOrcaRouter',
         'settings.calendar', 'settings.calendarMobile.icsSubscriptions',
     ],
     about: ['settings.about', 'settings.changelog', 'settings.checkForUpdates', 'settings.documentation'],

--- a/packages/core/src/ai-config.test.ts
+++ b/packages/core/src/ai-config.test.ts
@@ -62,6 +62,34 @@ describe('ai-config endpoint mapping', () => {
         expect(config.endpoint).toBeUndefined();
     });
 
+    it('points the OrcaRouter provider at the fixed gateway chat completions endpoint', () => {
+        const config = buildAIConfig(
+            createSettings({
+                provider: 'orcarouter',
+                model: 'orcarouter/fusion',
+                baseUrl: 'http://localhost:11434/v1',
+            }),
+            'sk-orca-test',
+        );
+        expect(config.endpoint).toBe('https://api.orcarouter.ai/v1/chat/completions');
+        expect(config.model).toBe('orcarouter/fusion');
+        // A stray base URL from a previous OpenAI config must not leak into the
+        // named gateway route, and OpenAI extra body params do not apply either.
+        expect(config.extraBodyParams).toBeUndefined();
+    });
+
+    it('uses the same fixed endpoint for the OrcaRouter copilot config', () => {
+        const config = buildCopilotConfig(
+            createSettings({
+                provider: 'orcarouter',
+                copilotModel: 'orcarouter/fusion-mini',
+            }),
+            'sk-orca-test',
+        );
+        expect(config.endpoint).toBe('https://api.orcarouter.ai/v1/chat/completions');
+        expect(config.reasoningEffort).toBe('minimal');
+    });
+
     it('applies OpenAI endpoint mapping to copilot config', () => {
         const config = buildCopilotConfig(
             createSettings({

--- a/packages/core/src/ai-config.ts
+++ b/packages/core/src/ai-config.ts
@@ -6,6 +6,9 @@ const AI_KEY_PREFIX = 'mindwtr-ai-key';
 const OPENAI_CHAT_COMPLETIONS_PATH = '/chat/completions';
 const OPENAI_TRANSCRIBE_PATH = '/audio/transcriptions';
 const OPENAI_TRANSCRIBE_URL = `https://api.openai.com/v1${OPENAI_TRANSCRIBE_PATH}`;
+// Fixed endpoint for the named OrcaRouter provider. Unlike the OpenAI provider's
+// user-pasted base URL, a gateway's own route is not something the user configures.
+const ORCAROUTER_CHAT_COMPLETIONS_URL = 'https://api.orcarouter.ai/v1/chat/completions';
 
 export function getAIKeyStorageKey(provider: AIProviderId): string {
     return `${AI_KEY_PREFIX}:${provider}`;
@@ -124,7 +127,9 @@ export function buildAIConfig(settings: AppData['settings'], apiKey: string): AI
     const defaults = getDefaultAIConfig(provider);
     const endpoint = provider === 'openai'
         ? resolveOpenAIEndpoint(settings.ai?.baseUrl)
-        : undefined;
+        : provider === 'orcarouter'
+            ? ORCAROUTER_CHAT_COMPLETIONS_URL
+            : undefined;
     const extraBodyParams = provider === 'openai'
         ? normalizeOpenAIExtraBodyParams(settings.ai?.openAIExtraBodyParams)
         : undefined;
@@ -143,7 +148,9 @@ export function buildCopilotConfig(settings: AppData['settings'], apiKey: string
     const provider = (settings.ai?.provider ?? 'openai') as AIProviderId;
     const endpoint = provider === 'openai'
         ? resolveOpenAIEndpoint(settings.ai?.baseUrl)
-        : undefined;
+        : provider === 'orcarouter'
+            ? ORCAROUTER_CHAT_COMPLETIONS_URL
+            : undefined;
     const extraBodyParams = provider === 'openai'
         ? normalizeOpenAIExtraBodyParams(settings.ai?.openAIExtraBodyParams)
         : undefined;

--- a/packages/core/src/ai/ai-service.ts
+++ b/packages/core/src/ai/ai-service.ts
@@ -11,6 +11,11 @@ export function createAIProvider(config: AIProviderConfig): AIProvider {
             return createOpenAIProvider(config);
         case 'anthropic':
             return createAnthropicProvider(config);
+        case 'orcarouter':
+            // OrcaRouter is an OpenAI-compatible gateway; the OpenAI provider's
+            // requestOpenAI uses config.endpoint when set, so the fixed
+            // OrcaRouter URL from buildAIConfig flows through here.
+            return createOpenAIProvider(config);
         default:
             throw new Error(`Unsupported AI provider: ${config.provider}`);
     }

--- a/packages/core/src/ai/catalog.test.ts
+++ b/packages/core/src/ai/catalog.test.ts
@@ -7,6 +7,12 @@ import {
     OPENAI_COPILOT_DEFAULT_MODEL,
     OPENAI_DEFAULT_MODEL,
     OPENAI_MODEL_OPTIONS,
+    ORCAROUTER_COPILOT_DEFAULT_MODEL,
+    ORCAROUTER_DEFAULT_MODEL,
+    ORCAROUTER_MODEL_OPTIONS,
+    getDefaultAIConfig,
+    getDefaultCopilotModel,
+    getModelOptions,
     resolveAnthropicModel,
     resolveGeminiModel,
 } from './catalog';
@@ -22,6 +28,21 @@ describe('current model lineup (#985)', () => {
         expect(ANTHROPIC_MODEL_OPTIONS).toContain('claude-opus-5');
         expect(ANTHROPIC_MODEL_OPTIONS).toContain(ANTHROPIC_DEFAULT_MODEL);
         expect(ANTHROPIC_MODEL_OPTIONS).toContain('claude-haiku-4-5');
+    });
+});
+
+describe('OrcaRouter provider', () => {
+    it('defaults to the gateway fusion route with fusion-mini as the copilot tier', () => {
+        expect(ORCAROUTER_DEFAULT_MODEL).toBe('orcarouter/fusion');
+        expect(ORCAROUTER_COPILOT_DEFAULT_MODEL).toBe('orcarouter/fusion-mini');
+        expect(ORCAROUTER_MODEL_OPTIONS).toContain(ORCAROUTER_DEFAULT_MODEL);
+        expect(ORCAROUTER_MODEL_OPTIONS).toContain(ORCAROUTER_COPILOT_DEFAULT_MODEL);
+    });
+
+    it('resolves the orcarouter provider defaults and options through the catalog helpers', () => {
+        expect(getDefaultAIConfig('orcarouter').model).toBe(ORCAROUTER_DEFAULT_MODEL);
+        expect(getModelOptions('orcarouter')).toEqual(ORCAROUTER_MODEL_OPTIONS);
+        expect(getDefaultCopilotModel('orcarouter')).toBe(ORCAROUTER_COPILOT_DEFAULT_MODEL);
     });
 });
 

--- a/packages/core/src/ai/catalog.ts
+++ b/packages/core/src/ai/catalog.ts
@@ -14,6 +14,14 @@ export const ANTHROPIC_DEFAULT_MODEL = 'claude-sonnet-5';
 export const OPENAI_COPILOT_DEFAULT_MODEL = OPENAI_FAST_MODEL;
 export const GEMINI_COPILOT_DEFAULT_MODEL = 'gemini-3.5-flash-lite';
 export const ANTHROPIC_COPILOT_DEFAULT_MODEL = 'claude-haiku-4-5';
+// OrcaRouter is an OpenAI-compatible routing gateway: the `orcarouter/*` ids
+// it exposes are gateway-level routes (fusion = flagship, fusion-mini = fast
+// tier), not a single vendor's model. Verified live on the gateway's
+// /v1/chat/completions endpoint before adding. Brand-named vendor ids are
+// listed as suggestions too; the live /v1/models fetch in model-list.ts
+// replaces this list whenever an API key is present.
+export const ORCAROUTER_DEFAULT_MODEL = 'orcarouter/fusion';
+export const ORCAROUTER_COPILOT_DEFAULT_MODEL = 'orcarouter/fusion-mini';
 export const DEFAULT_GEMINI_THINKING_BUDGET = 0;
 export const DEFAULT_ANTHROPIC_THINKING_BUDGET = 0;
 
@@ -36,6 +44,15 @@ export const ANTHROPIC_MODEL_OPTIONS = [
     'claude-haiku-4-5',
     'claude-opus-5',
     'claude-opus-4-8',
+];
+export const ORCAROUTER_MODEL_OPTIONS = [
+    ORCAROUTER_DEFAULT_MODEL,
+    ORCAROUTER_COPILOT_DEFAULT_MODEL,
+    'orcarouter/fusion-flash',
+    'orcarouter/free',
+    'openai/gpt-5.6-terra',
+    'anthropic/claude-sonnet-5',
+    'google/gemini-3.6-flash',
 ];
 
 
@@ -104,7 +121,9 @@ export function getDefaultAIConfig(provider: AIProviderId): AIProviderConfig {
                 ? OPENAI_DEFAULT_MODEL
                 : provider === 'anthropic'
                     ? ANTHROPIC_DEFAULT_MODEL
-                    : GEMINI_DEFAULT_MODEL,
+                    : provider === 'orcarouter'
+                        ? ORCAROUTER_DEFAULT_MODEL
+                        : GEMINI_DEFAULT_MODEL,
         reasoningEffort: DEFAULT_REASONING_EFFORT,
         ...(provider === 'gemini' ? { thinkingBudget: DEFAULT_GEMINI_THINKING_BUDGET } : {}),
         ...(provider === 'anthropic' ? { thinkingBudget: DEFAULT_ANTHROPIC_THINKING_BUDGET } : {}),
@@ -114,12 +133,14 @@ export function getDefaultAIConfig(provider: AIProviderId): AIProviderConfig {
 export function getModelOptions(provider: AIProviderId): string[] {
     if (provider === 'openai') return OPENAI_MODEL_OPTIONS;
     if (provider === 'anthropic') return ANTHROPIC_MODEL_OPTIONS;
+    if (provider === 'orcarouter') return ORCAROUTER_MODEL_OPTIONS;
     return GEMINI_MODEL_OPTIONS;
 }
 
 export function getDefaultCopilotModel(provider: AIProviderId): string {
     if (provider === 'openai') return OPENAI_COPILOT_DEFAULT_MODEL;
     if (provider === 'anthropic') return ANTHROPIC_COPILOT_DEFAULT_MODEL;
+    if (provider === 'orcarouter') return ORCAROUTER_COPILOT_DEFAULT_MODEL;
     return GEMINI_COPILOT_DEFAULT_MODEL;
 }
 

--- a/packages/core/src/ai/model-list.test.ts
+++ b/packages/core/src/ai/model-list.test.ts
@@ -218,6 +218,24 @@ describe('fetchProviderModels: anthropic', () => {
     });
 });
 
+describe('fetchProviderModels: orcarouter', () => {
+    it('hits the gateway /v1/models root, sends the bearer key, and applies the chat filter', async () => {
+        const { fetchImpl, calls } = captureFetch(() => jsonResponse({
+            data: [
+                { id: 'orcarouter/fusion', created: 5 },
+                { id: 'openai/text-embedding-3-small', created: 4 },
+                { id: 'openai/gpt-5.6-terra', created: 3 },
+            ],
+        }));
+
+        const models = await fetchProviderModels('orcarouter', { fetchImpl, apiKey: 'sk-orca-test' });
+
+        expect(models).toEqual(['orcarouter/fusion', 'openai/gpt-5.6-terra']);
+        expect(calls[0].url).toBe('https://api.orcarouter.ai/v1/models');
+        expect(calls[0].init.headers).toEqual({ Authorization: 'Bearer sk-orca-test' });
+    });
+});
+
 describe('fetchProviderModels: timeout', () => {
     beforeEach(() => vi.useFakeTimers());
     afterEach(() => vi.useRealTimers());

--- a/packages/core/src/ai/model-list.ts
+++ b/packages/core/src/ai/model-list.ts
@@ -5,7 +5,7 @@
 // something the caller degrades from — see mergeModelOptions.
 import { fetchWithTimeout } from './utils';
 
-export type ModelListProviderId = 'openai' | 'gemini' | 'anthropic';
+export type ModelListProviderId = 'openai' | 'gemini' | 'anthropic' | 'orcarouter';
 export type ModelListKind = 'chat' | 'transcription';
 
 export type FetchProviderModelsOptions = {
@@ -50,6 +50,7 @@ async function readJsonBody(response: Response, label: string): Promise<unknown>
 // --- OpenAI --------------------------------------------------------------
 
 const OPENAI_DEFAULT_ROOT = 'https://api.openai.com/v1';
+const ORCAROUTER_DEFAULT_ROOT = 'https://api.orcarouter.ai/v1';
 const OPENAI_CHAT_EXCLUDE = /(embed|tts|audio|whisper|transcribe|realtime|image|dall-e|moderation)/i;
 const OPENAI_TRANSCRIBE_INCLUDE = /(whisper|transcribe)/i;
 
@@ -185,6 +186,12 @@ export function fetchProviderModels(
     options: FetchProviderModelsOptions = {}
 ): Promise<string[]> {
     const resolved = resolveOptions(options);
+    // OrcaRouter is OpenAI-compatible, so it reuses the OpenAI list parser with
+    // the gateway's own root. Its /v1/models payload is namespaced
+    // (`vendor/model` and `orcarouter/*`), which the chat filter handles fine.
+    if (provider === 'orcarouter') {
+        return fetchOpenAIModels({ ...resolved, baseUrl: resolved.baseUrl || ORCAROUTER_DEFAULT_ROOT });
+    }
     if (provider === 'openai') return fetchOpenAIModels(resolved);
     if (provider === 'gemini') return fetchGeminiModels(resolved);
     return fetchAnthropicModels(resolved);

--- a/packages/core/src/ai/types.ts
+++ b/packages/core/src/ai/types.ts
@@ -1,6 +1,6 @@
 import type { TimeEstimate } from '../types';
 
-export type AIProviderId = 'gemini' | 'openai' | 'anthropic';
+export type AIProviderId = 'gemini' | 'openai' | 'anthropic' | 'orcarouter';
 
 // 'minimal' minimizes reasoning tokens for the fastest time-to-first-token on
 // latency-sensitive paths (e.g. the copilot type-ahead) on GPT-5 reasoning models.

--- a/packages/core/src/i18n/locale-quality.ts
+++ b/packages/core/src/i18n/locale-quality.ts
@@ -11,6 +11,7 @@ export const allowedEnglishMirrorTerms = [
     'Gemini',
     'Anthropic',
     'Claude',
+    'OrcaRouter',
     'Pomodoro',
     'GTD',
     'ICS',

--- a/packages/core/src/i18n/locales/ar.ts
+++ b/packages/core/src/i18n/locales/ar.ts
@@ -937,6 +937,7 @@ export const arOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'تَوأَم',
         'settings.aiProviderAnthropic': 'أنثروبي (كلود)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'قليل',
         'settings.aiEffortMedium': 'واسطة',
         'settings.aiEffortHigh': 'عالي',

--- a/packages/core/src/i18n/locales/cs.ts
+++ b/packages/core/src/i18n/locales/cs.ts
@@ -1174,6 +1174,7 @@ export const csOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Nízké',
         'settings.aiEffortMedium': 'Střední',
         'settings.aiEffortHigh': 'Vysoké',

--- a/packages/core/src/i18n/locales/de.ts
+++ b/packages/core/src/i18n/locales/de.ts
@@ -927,6 +927,7 @@ export const deOverrides: Record<string, string> = {
         'settings.aiReasoningHintFoss': 'Von unterstützten Modellen benutzt.',
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Niedrig',
         'settings.aiEffortMedium': 'Mittel',
         'settings.aiEffortHigh': 'Hoch',

--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -1200,6 +1200,7 @@ export const en: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Low',
         'settings.aiEffortMedium': 'Medium',
         'settings.aiEffortHigh': 'High',

--- a/packages/core/src/i18n/locales/es.ts
+++ b/packages/core/src/i18n/locales/es.ts
@@ -841,6 +841,7 @@ export const esOverrides: Record<string, string> = {
         'settings.aiReasoningHint': 'Usado por modelos GPT-5.',
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Bajo',
         'settings.aiEffortMedium': 'Medio',
         'settings.aiEffortHigh': 'Alto',

--- a/packages/core/src/i18n/locales/fa.ts
+++ b/packages/core/src/i18n/locales/fa.ts
@@ -1176,6 +1176,7 @@ export const faOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'کم',
         'settings.aiEffortMedium': 'متوسط',
         'settings.aiEffortHigh': 'زیاد',

--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -1110,6 +1110,7 @@ export const frOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Faible',
         'settings.aiEffortMedium': 'Moyen',
         'settings.aiEffortHigh': 'Élevé',

--- a/packages/core/src/i18n/locales/hi.ts
+++ b/packages/core/src/i18n/locales/hi.ts
@@ -889,6 +889,7 @@ export const hiOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'ओपनएआई',
         'settings.aiProviderGemini': 'मिथुन',
         'settings.aiProviderAnthropic': 'एंथ्रोपिक (क्लाउड)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'कम',
         'settings.aiEffortMedium': 'मध्यम',
         'settings.aiEffortHigh': 'उच्च',

--- a/packages/core/src/i18n/locales/it.ts
+++ b/packages/core/src/i18n/locales/it.ts
@@ -1002,6 +1002,7 @@ export const itOverrides: Record<string, string> = {
         'settings.aiReasoningHintFoss': 'Usato dai modelli supportati.',
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Basso',
         'settings.aiEffortMedium': 'Medio',
         'settings.aiEffortHigh': 'Alto',

--- a/packages/core/src/i18n/locales/ja.ts
+++ b/packages/core/src/i18n/locales/ja.ts
@@ -889,6 +889,7 @@ export const jaOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'ジェミニ',
         'settings.aiProviderAnthropic': '人間性（クロード）',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': '低い',
         'settings.aiEffortMedium': '中くらい',
         'settings.aiEffortHigh': '高い',

--- a/packages/core/src/i18n/locales/ko.ts
+++ b/packages/core/src/i18n/locales/ko.ts
@@ -1211,6 +1211,7 @@ export const koOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': '낮은',
         'settings.aiEffortMedium': '중간',
         'settings.aiEffortHigh': '높은',

--- a/packages/core/src/i18n/locales/nl.ts
+++ b/packages/core/src/i18n/locales/nl.ts
@@ -519,6 +519,7 @@ export const nlOverrides: Record<string, string> = {
         'settings.speechBaseUrl': 'URL van transcriptieserver',
         'settings.speechBaseUrlHint': 'Laat leeg voor officiële OpenAI. Stel dit in voor een zelf gehoste OpenAI-compatibele transcriptieserver. API-sleutel is optioneel.',
         'settings.aiProviderGemini': 'Gemini',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.gtd': 'GTD',
         'settings.notificationsDisabled': 'Meldingen uitgeschakeld',

--- a/packages/core/src/i18n/locales/pl.ts
+++ b/packages/core/src/i18n/locales/pl.ts
@@ -886,6 +886,7 @@ export const plOverrides: Record<string, string> = {
         'settings.aiReasoningHintFoss': 'Używany przez obsługiwane modele.',
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Niski',
         'settings.aiEffortMedium': 'Średni',
         'settings.aiEffortHigh': 'Wysoki',

--- a/packages/core/src/i18n/locales/pt.ts
+++ b/packages/core/src/i18n/locales/pt.ts
@@ -943,6 +943,7 @@ export const ptOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gêmeos',
         'settings.aiProviderAnthropic': 'Antrópico (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Baixo',
         'settings.aiEffortMedium': 'Médio',
         'settings.aiEffortHigh': 'Alto',

--- a/packages/core/src/i18n/locales/ru.ts
+++ b/packages/core/src/i18n/locales/ru.ts
@@ -889,6 +889,7 @@ export const ruOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'ОпенАИ',
         'settings.aiProviderGemini': 'Близнецы',
         'settings.aiProviderAnthropic': 'Антропный (Клод)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Низкий',
         'settings.aiEffortMedium': 'Середина',
         'settings.aiEffortHigh': 'Высокий',

--- a/packages/core/src/i18n/locales/sv.ts
+++ b/packages/core/src/i18n/locales/sv.ts
@@ -1176,6 +1176,7 @@ export const svOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Låg',
         'settings.aiEffortMedium': 'Medel',
         'settings.aiEffortHigh': 'Hög',

--- a/packages/core/src/i18n/locales/tr.ts
+++ b/packages/core/src/i18n/locales/tr.ts
@@ -901,6 +901,7 @@ export const trOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'İkizler burcu',
         'settings.aiProviderAnthropic': 'Antropik (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Düşük',
         'settings.aiEffortMedium': 'Orta',
         'settings.aiEffortHigh': 'Yüksek',

--- a/packages/core/src/i18n/locales/vi.ts
+++ b/packages/core/src/i18n/locales/vi.ts
@@ -1197,6 +1197,7 @@ export const viOverrides: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': 'Thấp',
         'settings.aiEffortMedium': 'Trung bình',
         'settings.aiEffortHigh': 'Cao',

--- a/packages/core/src/i18n/locales/zh-Hans.ts
+++ b/packages/core/src/i18n/locales/zh-Hans.ts
@@ -1130,6 +1130,7 @@ export const zhHans: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': '低',
         'settings.aiEffortMedium': '中',
         'settings.aiEffortHigh': '高',

--- a/packages/core/src/i18n/locales/zh-Hant.ts
+++ b/packages/core/src/i18n/locales/zh-Hant.ts
@@ -1130,6 +1130,7 @@ export const zhHant: Record<string, string> = {
         'settings.aiProviderOpenAI': 'OpenAI',
         'settings.aiProviderGemini': 'Gemini',
         'settings.aiProviderAnthropic': 'Anthropic (Claude)',
+        'settings.aiProviderOrcaRouter': 'OrcaRouter',
         'settings.aiEffortLow': '低',
         'settings.aiEffortMedium': '中',
         'settings.aiEffortHigh': '高',

--- a/packages/core/src/settings-options.ts
+++ b/packages/core/src/settings-options.ts
@@ -97,6 +97,7 @@ const AI_PROVIDER_VALUE_FLAGS: Record<AIProviderId, true> = {
     gemini: true,
     openai: true,
     anthropic: true,
+    orcarouter: true,
 };
 
 const AI_REASONING_EFFORT_VALUE_FLAGS: Record<AIReasoningEffort, true> = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -424,7 +424,7 @@ export interface NotificationSettings {
 
 export interface AiSettings {
     enabled?: boolean;
-    provider?: 'gemini' | 'openai' | 'anthropic';
+    provider?: 'gemini' | 'openai' | 'anthropic' | 'orcarouter';
     apiKey?: string;
     baseUrl?: string;
     model?: string;


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class AI provider in the desktop and mobile apps. OrcaRouter is an OpenAI-compatible model routing gateway exposing 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `packages/core/src/ai/types.ts`: extends `AIProviderId` with `'orcarouter'`
- `packages/core/src/types.ts`: adds `'orcarouter'` to the persisted `provider` setting union
- `packages/core/src/ai/catalog.ts`: OrcaRouter model catalog (default `orcarouter/fusion`, copilot default `orcarouter/fusion-mini`, plus fusion-flash, free and vendor model ids)
- `packages/core/src/ai-config.ts`: maps the provider to the fixed gateway endpoint `https://api.orcarouter.ai/v1/chat/completions` for chat and copilot configs
- `packages/core/src/ai/model-list.ts`: live model list fetch from `https://api.orcarouter.ai/v1/models` with the bearer key
- `packages/core/src/ai/ai-service.ts`: dispatches `orcarouter` to the OpenAI-compatible transport
- `packages/core/src/settings-options.ts`: registers the provider in the AI provider flags
- `apps/desktop/src/components/views/settings/SettingsAiPage.tsx` and `labels.ts`: provider option and settings-search label
- `apps/mobile/components/settings/ai-settings-assistant-orcarouter-panel.tsx`: new OrcaRouter panel (API key)
- `apps/mobile/components/settings/ai-settings-assistant-card.tsx`, `ai-settings-screen.tsx`, `settings.constants.ts`: provider toggle, label and search keywords
- `packages/core/src/i18n/`: provider label `settings.aiProviderOrcaRouter` across all 20 locales, plus a brand-name allowance in `locale-quality.ts`
- Tests: `catalog.test.ts`, `model-list.test.ts`, `ai-config.test.ts`, `SettingsAiPage.test.tsx`, `settings.search.test.ts`

## Why a named provider

Mindwtr's OpenAI provider doubles as the OpenAI-compatible escape hatch via a custom base URL, but that leaves model picking, copilot defaults and the live model list to manual configuration. A named provider gives OrcaRouter users the same first-class experience as the OpenAI, Gemini and Anthropic providers: fixed secure endpoint, curated model catalog, copilot default and one-tap key storage, on both desktop and mobile.

## How to use it

1. Get a free API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Open AI settings and pick OrcaRouter as the provider.
3. Paste your key. The model picker populates from the live catalog (`orcarouter/fusion`, `orcarouter/fusion-mini`, `orcarouter/fusion-flash`, `orcarouter/free`, plus vendor ids such as `openai/gpt-5.6-terra`).

## Verification

- Core unit tests: 177 targeted tests pass (`catalog`, `model-list`, `ai-config`, provider dispatch); full core suite has 5 pre-existing failures in date/recurrence/calendar-sorting modules untouched by this change
- Desktop and mobile typecheck: clean (`bunx tsc --noEmit`)
- i18n: locale-parity check resolves `settings.aiProviderOrcaRouter` in all 20 locales
- Live API: key validated against `https://api.orcarouter.ai/v1/models`; `orcarouter/fusion`, `fusion-mini`, `fusion-flash` and `free` confirmed reachable on `/v1/chat/completions`
