### PR TITLE
fix(sync): keep compressing proxies from breaking WebDAV conditional writes

### DIFF
--- a/apps/desktop/src-tauri/src/sync.rs
+++ b/apps/desktop/src-tauri/src/sync.rs
@@ -9427,7 +9427,7 @@ mod tests {
 
         let request = request_receiver.recv().expect("captured request");
         assert!(
-            request.contains("Accept-Encoding: identity"),
+            request.to_ascii_lowercase().contains("accept-encoding: identity"),
             "WebDAV reads must ask for the bytes as stored; got: {request}"
         );
     }

--- a/apps/desktop/src-tauri/src/sync.rs
+++ b/apps/desktop/src-tauri/src/sync.rs
@@ -3329,6 +3329,7 @@ fn webdav_fetch_optional_bytes(
     let response = client
         .get(target)
         .basic_auth(username, Some(password))
+        .header("Accept-Encoding", "identity")
         .send()
         .map_err(|error| format_reqwest_send_error("WebDAV request failed", &error))?;
     if response.status() == reqwest::StatusCode::NOT_FOUND {
@@ -3368,6 +3369,7 @@ fn webdav_get_json_blocking(
         client
             .get(target)
             .basic_auth(&username, Some(&password))
+            .header("Accept-Encoding", "identity")
             .send()
             .map_err(|e| format_reqwest_send_error("WebDAV request failed", &e))
     };
@@ -3551,6 +3553,7 @@ fn webdav_put_json_blocking(
         let request = client
             .put(url.clone())
             .basic_auth(&username, Some(&password))
+            .header("Accept-Encoding", "identity")
             .header("Content-Type", content_type)
             .body(payload.clone());
         let request = match &write_condition {
@@ -9389,6 +9392,44 @@ mod tests {
         assert!(error.contains("500 Internal Server Error"), "unexpected error: {error}");
         assert!(error.contains("backend unavailable"), "unexpected error: {error}");
         failed_server.join().expect("500 server");
+    }
+
+    #[test]
+    fn webdav_reads_ask_for_the_bytes_as_stored_with_identity_encoding() {
+        // A compressing proxy in front of the server (nginx, Apache mod_deflate,
+        // Cloudflare) otherwise serves data.json with a mutated ETag (weak `W/…`
+        // or mod_deflate's `-gzip` suffix) while the conditional write is checked
+        // against the stored one — every overwrite then 412s forever. Same trap
+        // as the TS client's `Accept-Encoding: identity` (#1056).
+        use std::io::{Read, Write};
+        use std::sync::mpsc;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind WebDAV test server");
+        let address = listener.local_addr().expect("server address");
+        let (request_sender, request_receiver) = mpsc::channel::<String>();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept WebDAV request");
+            let mut buffer = [0u8; 4096];
+            let read = stream.read(&mut buffer).unwrap_or(0);
+            let _ = request_sender.send(String::from_utf8_lossy(&buffer[..read]).to_string());
+            let body = "{\"tasks\":[]}";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nETag: \"v1\"\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).expect("write WebDAV response");
+        });
+
+        let client = blocking_http_client(None).expect("client");
+        let url = format!("http://{address}/data.json");
+        webdav_fetch_optional_bytes(&client, &url, "user", "pass").expect("identity fetch");
+        server.join().expect("server thread");
+
+        let request = request_receiver.recv().expect("captured request");
+        assert!(
+            request.contains("Accept-Encoding: identity"),
+            "WebDAV reads must ask for the bytes as stored; got: {request}"
+        );
     }
 
     #[test]

--- a/packages/core/src/sync-backend-io.ts
+++ b/packages/core/src/sync-backend-io.ts
@@ -343,7 +343,12 @@ export function createSyncBackendIO(ctx: SyncBackendContext, transport: SyncTran
                     return normalizeRemoteWriteResult('webdav', result);
                 } catch (error) {
                     if (isWebdavRemoteWriteConflictError(error)) {
-                        throw new SyncRemoteWriteConflict();
+                        // The native error message carries the rejecting HTTP
+                        // status ("… before replacement (412)"); keep it so the
+                        // requeue log can show why the server refused the write.
+                        throw new SyncRemoteWriteConflict(
+                            error instanceof Error ? error.message : String(error),
+                        );
                     }
                     throw error;
                 }

--- a/packages/core/src/sync-client-helpers.ts
+++ b/packages/core/src/sync-client-helpers.ts
@@ -12,11 +12,16 @@ export type LocalSyncAbortReason = 'local-data-changed' | 'remote-write-conflict
 
 export class LocalSyncAbort extends Error {
     readonly reason: LocalSyncAbortReason;
+    /** Transport-provided context for the abort, e.g. the HTTP status a WebDAV
+     *  conditional write was rejected with. Surfaced in the requeue log so a
+     *  server rejecting its own ETags (mod_deflate ETag mutation) is visible. */
+    readonly detail: string | null;
 
-    constructor(reason: LocalSyncAbortReason = 'local-data-changed') {
+    constructor(reason: LocalSyncAbortReason = 'local-data-changed', detail?: string) {
         super('Local changes detected during sync');
         this.name = 'LocalSyncAbort';
         this.reason = reason;
+        this.detail = detail ?? null;
     }
 }
 

--- a/packages/core/src/sync-run.test.ts
+++ b/packages/core/src/sync-run.test.ts
@@ -1545,7 +1545,9 @@ describe('runSharedSyncCycle', () => {
             remote: createData([createTask('t-remote', 'Remote task')]),
             io: {
                 writeRemote: vi.fn(async () => {
-                    throw new SyncRemoteWriteConflict();
+                    throw new SyncRemoteWriteConflict(
+                        'WEBDAV_REMOTE_WRITE_CONFLICT: WebDAV document changed before replacement (412)',
+                    );
                 }),
             },
         });
@@ -1558,9 +1560,14 @@ describe('runSharedSyncCycle', () => {
         expect(harness.diagnostics).toContain('requeued');
         // Desktop has no diagnostics sink: the requeue must also reach the plain
         // log with its reason, or a never-converging activation probe is invisible.
+        // The transport detail (e.g. the rejecting HTTP status) rides along so a
+        // server that breaks its own ETag chain shows up in one log line.
         expect(harness.infos).toContainEqual(expect.objectContaining({
             message: 'Sync cycle requeued',
-            extra: expect.objectContaining({ reason: 'remote-write-conflict' }),
+            extra: expect.objectContaining({
+                reason: 'remote-write-conflict',
+                detail: 'WEBDAV_REMOTE_WRITE_CONFLICT: WebDAV document changed before replacement (412)',
+            }),
         }));
     });
 

--- a/packages/core/src/sync-run.ts
+++ b/packages/core/src/sync-run.ts
@@ -1051,7 +1051,7 @@ class SharedSyncRunMachine {
             if (error instanceof SyncRemoteWriteConflict) {
                 // Another device wrote between readRemote and writeRemote; retry next cycle.
                 this.requestFollowUp();
-                throw new LocalSyncAbort('remote-write-conflict');
+                throw new LocalSyncAbort('remote-write-conflict', error.message);
             }
             throw error;
         }
@@ -1857,6 +1857,7 @@ class SharedSyncRunMachine {
                 backend: this.backend,
                 step: this.state.step ?? '-',
                 reason: error.reason,
+                detail: error.detail ?? '-',
                 activationProbe: String(this.options.activationProbe === true),
             });
             this.notifier.onDiagnostic?.({


### PR DESCRIPTION
## Summary
Native desktop WebDAV requests now send `Accept-Encoding: identity` (parity with the TS client, webdav.ts `buildHeaders`, #1056), so a compressing proxy can no longer serve data.json with an ETag variant (`-gzip` suffix, weak `W/…`) that the server's own `If-Match` check then rejects.

The conflict path also keeps the transport error message now.

## Related issue
Fixes #1170 

## Testing
- `packages/core`: vitest run of sync-run/sync-backend-io/sync-client-helpers/sync-cycle → 202/202 pass, incl. the extended requeue test pinning the new `detail` field.
- `typecheck:core`, `typecheck:desktop`, `typecheck:mobile` all pass.
- Rust: new header-capture test `webdav_reads_ask_for_the_bytes_as_stored_with_identity_encoding` (raw-TcpListener harness, same pattern as the existing 404 test)
- Live verification against the affected Nextcloud (Apache mod_deflate): with `Accept-Encoding: identity` (or the server-side `DeflateAlterETag NoChange` fix) the server serves the stored ETag, the conditional PUT returns 201, and sync converges on the next cycle.

## Screenshots / recordings
N/A

## Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](https://gist.github.com/dongdongbh/0446c35e1d5c1a73c344b16cba4aeeaa)
- [x] I have tested this change locally
- [x] I linked the relevant issue (or explained why there isn't one)
- [x] I added or updated tests/docs if needed
