### PR TITLE
fix(i18n): replace misused 'contexts.tags' with proper 'tags.title'

### DIFF
--- a/apps/desktop/src/components/views/settings/SettingsManagePage.tsx
+++ b/apps/desktop/src/components/views/settings/SettingsManagePage.tsx
@@ -743,7 +743,7 @@ export function SettingsManagePage({ t: _t, translate, requestConfirmation }: Se
             {/* Tags */}
             <ManageSection
                 settingsKey="manageTags"
-                title={resolveText('contexts.tags', 'Tags')}
+                title={resolveText('tags.title', 'Tags')}
                 count={allTags.length}
             >
                 {allTags.length === 0 && (


### PR DESCRIPTION
## Summary
The `contexts.*` namespace is reserved for task context features (e.g., @home, @work). Using `contexts.tags` for a UI section title in `SettingsManagePage` is semantically incorrect.

Switch to the existing `tags.title` key, which belongs to the proper `tags.*` namespace for the tags feature.

This aligns with the project's i18n namespace convention and resolves the false positive in `i18n-missing-keys.test.ts`.

## Related issue

<!-- Link to GitHub issue if applicable, e.g. "Fixes #123" -->

## Testing

<!-- Commands run, platforms/devices checked, and outcomes -->

## Screenshots / recordings

<img width="1920" height="1008" alt="圖片" src="https://github.com/user-attachments/assets/2b3c99bc-e971-4aa7-b423-d632e60238c8" />

## Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](https://gist.github.com/dongdongbh/0446c35e1d5c1a73c344b16cba4aeeaa)
- [ ] I have tested this change locally
- [ ] I linked the relevant issue (or explained why there isn't one)
- [ ] I added or updated tests/docs if needed
